### PR TITLE
[#3] Extract all OccName's from module body

### DIFF
--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -22,15 +22,17 @@ library
                        Smuggler
                          Smuggler.Anns
                          Smuggler.Debug
+                         Smuggler.Name
                          Smuggler.Parser
 
   ghc-options:         -Wall
-  build-depends:       base-noprelude
+  build-depends:       base-noprelude >= 4.9 && < 5
                      , containers >= 0.5
                      , fmt
-                     , ghc
+                     , ghc == 8.2.2
                      , ghc-exactprint
                      , pretty-simple
+                     , syb
                      , universum >= 1.2.0
 
   default-extensions:  DeriveGeneric
@@ -39,6 +41,7 @@ library
                        LambdaCase
                        OverloadedStrings
                        RecordWildCards
+                       ScopedTypeVariables
 
   default-language:    Haskell2010
 

--- a/src/Smuggler/Name.hs
+++ b/src/Smuggler/Name.hs
@@ -1,0 +1,11 @@
+module Smuggler.Name
+       ( moduleBodyNames
+       ) where
+
+import Data.Generics.Schemes (listify)
+import GHC (GenLocated (..), ParsedSource)
+import HsSyn (HsModule (..))
+import OccName (OccName)
+
+moduleBodyNames :: ParsedSource -> [OccName]
+moduleBodyNames (L _ ast) = ordNub $ listify (\(_ :: OccName) -> True) (hsmodDecls ast)

--- a/src/Smuggler/Parser.hs
+++ b/src/Smuggler/Parser.hs
@@ -7,10 +7,12 @@ import Control.Exception (throwIO)
 import Language.Haskell.GHC.ExactPrint (Anns, exactPrint, parseModule)
 
 import HsSyn (HsModule (..))
+import OccName (occNameString)
 import RdrName (RdrName)
 import SrcLoc (Located)
 
 import Smuggler.Anns (removeAnnAtLoc)
+import Smuggler.Name (moduleBodyNames)
 -- import Smuggler.Debug (debugAST)
 
 parseFile :: IO ()
@@ -19,6 +21,9 @@ parseFile = do
     (anns, ast) <- runParser path
     -- debugAST anns
     putStrLn $ exactPrint ast $ removeAnnAtLoc 4 19 anns
+
+    putTextLn "=== OccNames ==="
+    putTextLn $ unlines $ map (toText . occNameString) $ moduleBodyNames ast
 
 runParser :: FilePath -> IO (Anns, Located (HsModule RdrName))
 runParser fileName = do

--- a/test/input.hs
+++ b/test/input.hs
@@ -2,3 +2,6 @@ module Test
        ( someFunc
        ) where
 import Foo (A (A, B, aaa), B (..), foo)
+
+bar :: A
+bar = foo


### PR DESCRIPTION
If I run test executable (on testing input) I can see this:

```
=== OccNames ===
bar
A
foo
```