### PR TITLE
[#19] Introduce simple function which prints sources of the module

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,10 @@
 module Main where
 
+import Data.List (sort)
+import Data.Maybe (fromMaybe, maybe)
+
+foo = False
+
 main :: IO ()
-main = return ()
+main = print $ fromMaybe True Nothing
 -- main = parseFile

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -32,9 +32,9 @@ library
   ghc-options:         -Wall
   build-depends:       base >= 4.12 && < 5
                      , ghc >= 8.6.0
+--                      , ghc-exactprint
 --                      , containers >= 0.5
 --                      , fmt
---                      , ghc-exactprint
 --                      , pretty-simple
 --                      , syb
 --                      , universum >= 1.2.0

--- a/src/Smuggler/Plugin.hs
+++ b/src/Smuggler/Plugin.hs
@@ -2,56 +2,41 @@ module Smuggler.Plugin
        ( plugin
        ) where
 
-import Avail
-import Control.Monad.IO.Class
+import Control.Monad.IO.Class (MonadIO (..))
+-- import Language.Haskell.GHC.ExactPrint (exactPrint, parseModule)
+
 import DynFlags (getDynFlags)
-import HscTypes
-import HsDecls
-import HsDoc
-import HsExpr
-import HsExtension
-import HsImpExp
-import Outputable
-import Plugins
-import TcRnTypes
+import FastString (unpackFS)
+import HscTypes (HsParsedModule, Hsc, ModSummary (..))
+import Outputable (ppr, showSDoc)
+import Plugins (CommandLineOption, Plugin (..), defaultPlugin)
+import SrcLoc (srcSpanFile)
+import TcRnTypes (TcGblEnv (..), TcM)
+
+-- import Smuggler.Anns (removeAnnAtLoc)
 
 plugin :: Plugin
-plugin = defaultPlugin { parsedResultAction = parsedPlugin
-                       , renamedResultAction = Just renamedAction
-                       , typeCheckResultAction = typecheckPlugin
-                       , spliceRunAction = metaPlugin
-                       , interfaceLoadAction = interfaceLoadPlugin
-                       }
-
-parsedPlugin :: [CommandLineOption] -> ModSummary -> HsParsedModule -> Hsc HsParsedModule
-parsedPlugin _ _ pm
-  = do dflags <- getDynFlags
-       liftIO $ putStrLn $ "parsePlugin: \n" ++ (showSDoc dflags $ ppr $ hpm_module pm)
-       return pm
-
-renamedAction :: [CommandLineOption] -> ModSummary
-                    -> ( HsGroup GhcRn, [LImportDecl GhcRn]
-                       , Maybe [(LIE GhcRn, Avails)], Maybe LHsDocString )
-                    -> TcM ()
-renamedAction _ _ ( gr, _, _, _ )
-  = do dflags <- getDynFlags
-       liftIO $ putStrLn $ "typeCheckPlugin (rn): " ++ (showSDoc dflags $ ppr gr)
+plugin = defaultPlugin
+    { renamedResultAction = Just $ \_ _ _ -> pure ()
+    , typeCheckResultAction = typecheckPlugin
+    }
 
 typecheckPlugin :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
-typecheckPlugin _ _ tc
-  = do dflags <- getDynFlags
-       liftIO $ putStrLn $ "typeCheckPlugin (rn): \n" ++ (showSDoc dflags $ ppr $ tcg_rn_decls tc)
-       liftIO $ putStrLn $ "typeCheckPlugin (tc): \n" ++ (showSDoc dflags $ ppr $ tcg_binds tc)
-       return tc
+typecheckPlugin _ ms env = do
+--    dflags <- getDynFlags
+--     liftIO $ putStrLn $ "rn rn imports: \n" ++ (showSDoc dflags $ ppr $ tcg_rn_imports env)
+--
+--     liftIO $ putStrLn $ "decls: \n" ++ (showSDoc dflags $ ppr $ tcg_rn_decls env)
+--     liftIO $ putStrLn $ "src-span: \n" ++ (showSDoc dflags $ ppr $ srcSpanFile $ tcg_top_loc env)
 
-metaPlugin :: [CommandLineOption] -> LHsExpr GhcTc -> TcM (LHsExpr GhcTc)
-metaPlugin _ meta
-  = do dflags <- getDynFlags
-       liftIO $ putStrLn $ "meta: " ++ (showSDoc dflags $ ppr meta)
-       return meta
+    liftIO $ putStrLn $ "path: " ++ ms_hspp_file ms
 
-interfaceLoadPlugin :: [CommandLineOption] -> ModIface -> IfM lcl ModIface
-interfaceLoadPlugin _ iface
-  = do dflags <- getDynFlags
-       liftIO $ putStrLn $ "interface loaded: " ++ (showSDoc dflags $ ppr $ mi_module iface)
-       return iface
+    let modulePath = unpackFS $ srcSpanFile $ tcg_top_loc env
+--   (anns, ast@(L _ hsMod)) <- runParser modulePath
+    moduleSrc <- liftIO $ readFile modulePath
+    liftIO $ putStrLn $ "module source:\n" ++ moduleSrc
+
+    -- debugAST anns
+--    putStrLn $ exactPrint ast $ removeAnnAtLoc 4 29 anns
+
+    pure env


### PR DESCRIPTION
It's not possible to modify AST using arguments for plugin functions. But what's possible is parse module with `ghc-exactprint` and write back to file. But for now `ghc-exactprint` doesn't build with `ghc >= 8.6`:

* https://github.com/alanz/ghc-exactprint/issues/65

So I just remove redundant parts from existing code. It contains some comments and doesn't do anything smart but this will be fixed in future.