### PR TITLE
[#31] Do nothing on parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,25 @@
 
 [![Hackage](https://img.shields.io/hackage/v/smuggler.svg)](https://hackage.haskell.org/package/smuggler)
 [![Build status](https://secure.travis-ci.org/kowainik/smuggler.svg)](https://travis-ci.org/kowainik/smuggler)
-[![Windows build status](https://ci.appveyor.com/api/projects/status/github/kowainik/smuggler?branch=master&svg=true)](https://ci.appveyor.com/project/kowainik/smuggler)
 [![MPL-2.0 license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](https://github.com/kowainik/smuggler/blob/master/LICENSE)
 
-Smuggling
+Haskell Compiler Plugin which removes unused imports automatically.
 
 ## Build instructions
 
-### First time
+Requirements:
+
+* `ghc >= ghc-8.6.1-alpha2`
+
+### Build project
 
 ```shell
-$ mkdir deps
-$ cd deps
-$ git clone git@github.com:alanz/ghc-exactprint.git
-$ cd ghc-exactprint
-$ git checkout ghc-8.6
-$ # comment line with `hashable` package in `packages` field in `cabal.project` file
-$ cd ../..
+$ cabal new-update
 $ cabal new-build --allow-newer
 ```
 
-### Second time
+### Run tests
 
-```shell
-$ cabal new-build --allow-newer
+```shel
+$ cabal new-test --allow-newer
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ $ cabal new-build --allow-newer
 
 ### Run tests
 
-```shel
+```shell
 $ cabal new-test --allow-newer
 ```

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -1,15 +1,15 @@
 name:                smuggler
 version:             0.0.0
-description:         Smuggling
 synopsis:            Smuggling
+description:         GHC compiler plugin which helps to manage imports
 homepage:            https://github.com/kowainik/smuggler
 bug-reports:         https://github.com/kowainik/smuggler/issues
-license:             MIT
+license:             MPL-2.0
 license-file:        LICENSE
 author:              Kowainik
 maintainer:          xrom.xkov@gmail.com
 copyright:           2018 Kowainik
-category:            Development
+category:            Development, Refactoring
 build-type:          Simple
 extra-doc-files:     README.md
                    , CHANGELOG.md

--- a/src/Prelude.txt
+++ b/src/Prelude.txt
@@ -1,8 +1,0 @@
--- | Uses [universum](https://hackage.haskell.org/package/universum) as default Prelude.
-
-module Prelude
-       ( module Universum
-       ) where
-
-import Universum
-

--- a/src/Smuggler/Parser.hs
+++ b/src/Smuggler/Parser.hs
@@ -2,40 +2,20 @@ module Smuggler.Parser
        ( runParser
        ) where
 
-import Control.Exception (throwIO)
-import Control.Exception (Exception)
 import Language.Haskell.GHC.ExactPrint (Anns, parseModule)
 
 import HsExtension (GhcPs)
 import HsSyn (HsModule (..))
 import SrcLoc (Located)
 
--- import Smuggler.Import (getLocationMap)
--- import Smuggler.Name (moduleBodyNames)
--- import Smuggler.Debug (debugAST)
-
--- parseFile :: IO ()
--- parseFile = do
---     let path = "test/input.hs"
---     (anns, ast@(L _ hsMod)) <- runParser path
---     -- debugAST anns
---     putStrLn $ exactPrint ast $ removeAnnAtLoc 5 22 anns
---
---     -- imports
---     putTextLn "=== Imports map ==="
---     putTextLn $ show $ keys $ getLocationMap hsMod
---
---     putTextLn "=== OccNames ==="
---     putTextLn $ unlines $ map (toText . occNameString) $ moduleBodyNames ast
-
-runParser :: FilePath -> IO (Anns, Located (HsModule GhcPs))
+runParser :: FilePath -> IO (Either () (Anns, Located (HsModule GhcPs)))
 runParser fileName = do
     res <- parseModule fileName
-    case res of
-        Right x              -> pure x
-        Left (_srcSpan, str) -> throwIO $ ParseException str
+    pure $ case res of
+        Left (_srcSpan, _str) -> Left ()
+        Right x               -> Right x
 
-newtype ParseException = ParseException String
-    deriving (Show)
-
-instance Exception ParseException
+-- newtype ParseException = ParseException String
+--     deriving (Show)
+--
+-- instance Exception ParseException


### PR DESCRIPTION
Resolves #31 

Also: I modify file names and replace `/` with `dots` to support modules with same names but different paths. And I changed README and `.cabal` file slightly to prepare for release and to remove old information.