### PR TITLE
Improve test output

### DIFF
--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -100,6 +100,7 @@ test-suite smuggler-test
                        Test.WildcardUnused
 
   build-depends:       base
+                     , ansi-terminal
                      , directory
                      , filepath
                      , smuggler


### PR DESCRIPTION
This sends additional output if a test fails (test name, contents of test input and golden). I would like to work on displaying just a diff. Would coloring the terminal output be overkill?