### PR TITLE
Update for GHC 8.8.3

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,4 +1,4 @@
-name: Haskell CI
+name: Smuggler
 
 on:
   push:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix: 
         ghc: ['8.10.1', '8.8.3']
-        cabal: ['3.2.0.0']
+        cabal: ['3.2']
         os: [ubuntu-latest]  
 
     name: Haskell GHC ${{ matrix.ghc }} smuggler

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,55 @@
+name: Haskell CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: 
+        ghc: ['8.10.1', '8.8.3']
+        cabal: ['3.2.0.0']
+        os: [ubuntu-latest]  
+
+    name: Haskell GHC ${{ matrix.ghc }} smuggler
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Haskell
+      uses: actions/setup-haskell@v1
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+
+    - name: Cache Cabal
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ matrix.ghc }}-
+          ${{ runner.os }}-
+
+    - uses: actions/cache@v1
+      name: Cache dist-newstyle
+      with:
+        path: dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.ghc }}-dist-newstyle
+
+    - name: Install dependencies
+      run: |
+        cabal update
+        cabal build --only-dependencies --enable-tests --enable-benchmarks
+    
+    - name: Build
+      run: cabal build --enable-tests all
+    
+    - name: Run tests
+      run: cabal test all

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ cache:
 
 matrix:
   include:
-  - ghc: 8.6.5
-  - ghc: 8.6.5
+  - ghc: 8.8.3
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: haskell
 git:
   depth: 5
 
-cabal: 3.0
+cabal: 3.2
 
 cache:
   directories:
@@ -21,6 +21,7 @@ install:
   - |
     if [ -z "$STACK_YAML" ]; then
       cabal update
+      cabal build -fdebug --enable-tests --enable-benchmarks
       cabal build --enable-tests --enable-benchmarks
     else
       curl -sSL https://get.haskellstack.org/ | sh
@@ -31,6 +32,7 @@ script:
   - |
     if [ -z "$STACK_YAML" ]; then
       cabal test --enable-tests
+      cabal test -f =debug
     else
       stack test --system-ghc --no-terminal
     fi

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ compiler options:
 -fplugin=Smuggler.Plugin
 ```
 
-If you want to generate a new source file rather than replacing the original
+If you want to generate a source files rather than replacing the originals
 then also add an additional compiler option:
 
 ```
 -fplugins-opt=Smuggler.Plugin:new
 ```
-say.  This will create  new output files with the given suffix
- (`.new`, in this case).
+say.  This will create output files with the given suffix
+ (`.new`, in this case) rather the rewriting the originals.
 
 A lovely addition to this package is that it automatically supports on-the-fly
 feature if you use it with `ghcid`. Smuggler doesn't perform file changes when
@@ -62,6 +62,12 @@ Requirements:
 ```shell
 cabal update
 cabal build
+```
+
+To build with debugging:
+
+```shell
+cabal bulid -fdebug
 ```
 
 #### Stack: How to build?

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 >
 > ― Amara Lakhous, Clash of Civilizations Over an Elevator in Piazza Vittorio
 
-Haskell Source Plugin which removes unused imports automatically.
+Haskell Source Plugin which removes unused imports and adds explicit exports automatically.
 
 ## How to use
 
@@ -23,14 +23,25 @@ compiler options:
 -fplugin=Smuggler.Plugin
 ```
 
-If you want to generate a source files rather than replacing the originals
-then also add an additional compiler option:
+The Plugin has serveral (case-inseneitive) options:
 
+* `NoImportProcessing` - do no import processing
+* `PreserveInstanceImports` - remove unused imports, but preserve a library import stub.
+such as  `import Mod ()`, to import only instances of typeclasses from it.
+* `MinimiseImports` - remove unused imports, including any that may be needed to
+import typeclass instances.  This may, therefore, stop the module from compiling.
+* `NoExportProcessing` - do no export processing
+* `AddExplicitExports` - add an explicit list of all available exports if there is none.
+You may want to edit it to keep specific values, types or classes local to the module.
+* `ReplaceExports` - replace any existing module export list with one containing all
+available exports (which you can, of course, then prune to your requirements).
+
+Any other option value is used to generate a source file with the option value used as a suffix
+rather than replacing the original file. For example,
 ```
 -fplugins-opt=Smuggler.Plugin:new
 ```
-say.  This will create output files with the given suffix
- (`.new`, in this case) rather the rewriting the originals.
+will create output files with the `.new` suffix rather the overwriting the originals.
 
 A lovely addition to this package is that it automatically supports on-the-fly
 feature if you use it with `ghcid`. Smuggler doesn't perform file changes when

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![Build](https://img.shields.io/travis/kowainik/smuggler.svg?logo=travis)](http://travis-ci.org/kowainik/smuggler)
 -->
 [![MPL-2.0 license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](https://github.com/kowainik/smuggler/blob/master/LICENSE)
-![GitHub CI](https://github.com/actions/smuggler/workflows/.github/workflows/haskell.yml/badge.svg)
+![Github CI](https://github.com/jrp2014/smuggler/workflows/Smuggler/badge.svg)
+
 
 > “So many people consider their work a daily punishment. Whereas I love my work
 > as a translator. Translation is a journey over a sea from one shore to the

--- a/README.md
+++ b/README.md
@@ -23,7 +23,16 @@ compiler options:
 -fplugin=Smuggler.Plugin
 ```
 
-Lovely addition to this package is that it automatically supports on-the-fly
+If you want to generate a new source file rather than replacing the original
+then also add an additional compiler option:
+
+```
+-fplugins-opt=Smuggler.Plugin:new
+```
+say.  This will create  new output files with the given suffix
+ (`.new`, in this case).
+
+A lovely addition to this package is that it automatically supports on-the-fly
 feature if you use it with `ghcid`. Smuggler doesn't perform file changes when
 there are no unused imports. So you can just run `ghcid` as usual:
 
@@ -31,11 +40,21 @@ there are no unused imports. So you can just run `ghcid` as usual:
 ghcid --command='cabal repl'
 ```
 
+## Caveats
+`smuggler` does not remove imports completely because an import may be being
+used to only import instances of typeclasses, So it will leave stubs like
+
+```haskell
+import Mod ()
+```
+
+that you may need to remove manually.
+
 ## For contributors
 
 Requirements:
 
-* `ghc-8.6.5`
+* `ghc-8.8.3`
 * `cabal >= 3.0` or `stack >= 2.0`
 
 ### Cabal: How to build?

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # smuggler
 
 ![smuggler-logo](https://user-images.githubusercontent.com/4276606/45937457-c2715c00-bff2-11e8-9766-f91051d36ffe.png)
+<!--
 [![Hackage](https://img.shields.io/hackage/v/smuggler.svg?logo=haskell)](https://hackage.haskell.org/package/smuggler)
 [![Build](https://img.shields.io/travis/kowainik/smuggler.svg?logo=travis)](http://travis-ci.org/kowainik/smuggler)
+-->
 [![MPL-2.0 license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](https://github.com/kowainik/smuggler/blob/master/LICENSE)
+![GitHub CI](https://github.com/actions/smuggler/workflows/.github/workflows/haskell.yml/badge.svg)
 
 > “So many people consider their work a daily punishment. Whereas I love my work
 > as a translator. Translation is a journey over a sea from one shore to the

--- a/README.md
+++ b/README.md
@@ -27,24 +27,25 @@ The Plugin has serveral (case-inseneitive) options:
 
 * `NoImportProcessing` - do no import processing
 * `PreserveInstanceImports` - remove unused imports, but preserve a library import stub.
-such as  `import Mod ()`, to import only instances of typeclasses from it.
+such as  `import Mod ()`, to import only instances of typeclasses from it. (The default.)
 * `MinimiseImports` - remove unused imports, including any that may be needed to
 import typeclass instances.  This may, therefore, stop the module from compiling.
+
 * `NoExportProcessing` - do no export processing
 * `AddExplicitExports` - add an explicit list of all available exports (excluding
-those that are imported) if there is no existing export list.
+those that are imported) if there is no existing export list. (The default.)
 You may want to edit it to keep specific values, types or classes local to the module.
 At present, a typeclass and its class methods are exported individually.  You may want to
-replace those exports with an abbreviation such as `C(..).
+replace those exports with an abbreviation such as `C(..)`.
 * `ReplaceExports` - replace any existing module export list with one containing all
 available exports (which you can, of course, then prune to your requirements).
 
-Any other option value is used to generate a source file with the option value used as a suffix
-rather than replacing the original file. For example,
+Any other option value is used to generate a source file with the option value used as
+a new extension rather than replacing the original file. For example,
 ```
 -fplugins-opt=Smuggler.Plugin:new
 ```
-will create output files with the `.new` suffix rather the overwriting the originals.
+will create output files with a `.new` suffix rather the overwriting the originals.
 
 A lovely addition to this package is that it automatically supports on-the-fly
 feature if you use it with `ghcid`. Smuggler doesn't perform file changes when

--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ such as  `import Mod ()`, to import only instances of typeclasses from it.
 * `MinimiseImports` - remove unused imports, including any that may be needed to
 import typeclass instances.  This may, therefore, stop the module from compiling.
 * `NoExportProcessing` - do no export processing
-* `AddExplicitExports` - add an explicit list of all available exports if there is none.
+* `AddExplicitExports` - add an explicit list of all available exports (excluding
+those that are imported) if there is no existing export list.
 You may want to edit it to keep specific values, types or classes local to the module.
+At present, a typeclass and its class methods are exported individually.  You may want to
+replace those exports with an abbreviation such as `C(..).
 * `ReplaceExports` - replace any existing module export list with one containing all
 available exports (which you can, of course, then prune to your requirements).
 

--- a/TODO
+++ b/TODO
@@ -1,0 +1,2 @@
+
+* refactor the much more sophisticated https://github.com/ddssff/refact-global-hse

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,5 @@
-module Main where
+module Main (
+  main ) where
 
 import Data.Bool ( bool)
 import Data.List ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,8 +1,8 @@
 module Main where
 
-import Data.Bool (Bool (False, True), bool)
-import Data.List (sort)
-import Data.Maybe (fromMaybe, maybe)
+import Data.Bool ( bool)
+import Data.List ()
+import Data.Maybe (fromMaybe)
 
 main :: IO ()
 main = do

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.4
 name:            smuggler
-version:         0.2.0.1
+version:         0.2.1.0
 synopsis:        GHC Source Plugin that helps to manage imports
 description:
   == Usage
@@ -36,7 +36,7 @@ source-repository head
 common common-options
   build-depends:      base ^>=4.13
   ghc-options:
-    -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wall -Wextra -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wcompat -Widentities -Wredundant-constraints -fhide-source-paths
 
   if flag(debug)
@@ -69,17 +69,14 @@ library
   if flag(debug)
     exposed-modules:
       Smuggler.Debug
--- Does not compile with 8.8.3      Smuggler.Import
       Smuggler.Name
 
+  -- Does not compile with 8.8.3      Smuggler.Import
   build-depends:
-    , bytestring            ^>=0.10
-    , containers            >=0.5   && <0.7
-    , filepath              ^>=1.4
-    , ghc                   ^>=8.8.0
-    , ghc-exactprint        ^>=0.6
-    , hashable              ^>=1.3
-    , unordered-containers  ^>=0.2.7
+    , containers      >=0.5   && <0.7
+    , filepath        ^>=1.4
+    , ghc             ^>=8.8.0
+    , ghc-exactprint  ^>=0.6
 
   if flag(debug)
     build-depends:
@@ -99,32 +96,29 @@ executable play-smuggler
 
   build-depends:  smuggler
 
-test-suite smuggler-test
+common common-tests
   import:         common-options
-  type:           exitcode-stdio-1.0
   hs-source-dirs: test
-  main-is:        Test.hs
   other-modules:
---    Test.BoolBoolUnused
---    Test.BoolBoolUsed
---    Test.BoolPartlyUsedFirst
---    Test.BoolPartlyUsedLast
---    Test.ConstructorsUnused
---    Test.Dummy
-    Test.ExportExplicit
-    Test.ExportImplicit
---    Test.ImplicitImportUnused
---    Test.ImplicitImportUsed
---    Test.ImportEmpty
---    Test.MultilineUnused
---    Test.TypeConstructorUnused
---    Test.TypeConstructorUnusedComma
---    Test.TypeConstructorUsed
---    Test.TypeUnused
---    Test.TypeUsed
---    Test.WildcardUnused
+    --Test.BoolBoolUnused
+    --Test.BoolBoolUsed
+    --Test.BoolPartlyUsedFirst
+    --Test.BoolPartlyUsedLast
+    --Test.ConstructorsUnused
+    --Test.Dummy
+    --Test.ExportExplicit
+    --Test.ExportImplicit
+    Test.ImplicitImportUnused
+    --Test.ImplicitImportUsed
+    --Test.ImportEmpty
+    --Test.MultilineUnused
+    --Test.TypeConstructorUnused
+    --Test.TypeConstructorUnusedComma
+    --Test.TypeConstructorUsed
+    --Test.TypeUnused
+    --Test.TypeUsed
+    --Test.WildcardUnused
 
---
   build-depends:
     , ansi-terminal
     , directory
@@ -135,3 +129,17 @@ test-suite smuggler-test
     -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-imports
     -fno-warn-missing-signatures -fplugin=Smuggler.Plugin
     -fplugin-opt=Smuggler.Plugin:test
+
+test-suite smuggler-test
+  import:  common-tests
+  type:    exitcode-stdio-1.0
+  main-is: Test.hs
+
+test-suite smuggler-test-maximal
+  import:  common-tests
+  type:    exitcode-stdio-1.0
+  main-is: Test.hs
+  ghc-options:
+    -fplugin-opt=Smuggler.Plugin:test
+    -fplugin-opt=Smuggler.Plugin:MinimiseImports
+    -fplugin-opt=Smuggler.Plugin:ReplaceExports

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -1,4 +1,4 @@
-cabal-version:   2.4
+cabal-version:   3.0
 name:            smuggler
 version:         0.2.1.0
 synopsis:        GHC Source Plugin that helps to manage imports
@@ -77,12 +77,12 @@ library
     , filepath        ^>=1.4
     , ghc             ^>=8.8.0
     , ghc-exactprint  ^>=0.6
+    , syb
 
   if flag(debug)
     build-depends:
       , fmt
       , pretty-simple
-      , syb
       , text
 
 executable play-smuggler

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -1,117 +1,132 @@
-cabal-version:       2.4
-name:                smuggler
-version:             0.2.0.1
-synopsis:            GHC Source Plugin that helps to manage imports
+cabal-version:   2.4
+name:            smuggler
+version:         0.2.0.1
+synopsis:        GHC Source Plugin that helps to manage imports
 description:
-    == Usage
-    .
-    Add @smuggler@ to the dependencies of your project.
-    .
-    Then add the following options: @-fplugin=Smuggler.Plugin@
+  == Usage
+  .
+  Add @smuggler@ to the dependencies of your project.
+  .
+  Then add the following to ghc-options: @-fplugin=Smuggler.Plugin@
 
-homepage:            https://github.com/kowainik/smuggler
-bug-reports:         https://github.com/kowainik/smuggler/issues
-license:             MPL-2.0
-license-file:        LICENSE
-author:              Dmitrii Kovanikov, Veronika Romashkina
-maintainer:          Kowainik <xrom.xkov@gmail.com>
-copyright:           2018-2019 Kowainik
-category:            Development, Refactoring
-build-type:          Simple
-extra-doc-files:     README.md
-                     CHANGELOG.md
-tested-with:         GHC == 8.8.3
+homepage:        https://github.com/kowainik/smuggler
+bug-reports:     https://github.com/kowainik/smuggler/issues
+license:         MPL-2.0
+license-file:    LICENSE
+author:          Dmitrii Kovanikov, Veronika Romashkina
+maintainer:      Kowainik <xrom.xkov@gmail.com>
+copyright:       2018-2019 Kowainik
+category:        Development, Refactoring
+build-type:      Simple
+extra-doc-files:
+  README.md
+  CHANGELOG.md
+
+tested-with:     GHC ==8.8.3
+
+flag debug
+  description: Enable debugging support
+  default:     False
+  manual:      True
 
 source-repository head
   type:     git
   location: git@github.com:kowainik/smuggler.git
 
 common common-options
-  build-depends:       base ^>= 4.13
-  ghc-options:         -Wall
-                       -Wincomplete-uni-patterns
-                       -Wincomplete-record-updates
-                       -Wcompat
-                       -Widentities
-                       -Wredundant-constraints
-                       -fhide-source-paths
-                       -ddump-minimal-imports
+  build-depends:      base ^>=4.13
+  ghc-options:
+    -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wcompat -Widentities -Wredundant-constraints -fhide-source-paths
 
-  default-language:    Haskell2010
-  default-extensions:  DeriveGeneric
-                       GeneralizedNewtypeDeriving
-                       InstanceSigs
-                       LambdaCase
-                       OverloadedStrings
-                       RecordWildCards
-                       ScopedTypeVariables
-                       StandaloneDeriving
-                       TypeApplications
+  if flag(debug)
+    ghc-options: -ddump-minimal-imports
 
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveGeneric
+    GeneralizedNewtypeDeriving
+    InstanceSigs
+    LambdaCase
+    OverloadedStrings
+    RecordWildCards
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
 
 library
-  import:              common-options
-  hs-source-dirs:      src
-  exposed-modules:     Smuggler.Anns
-                       Smuggler.Loc
-                       Smuggler.Parser
-                       Smuggler.Plugin
---                         Smuggler.Debug
---                         Smuggler.Import
---                         Smuggler.Name
+  import:          common-options
+  hs-source-dirs:  src
+  exposed-modules:
+    Smuggler.Anns
+    Smuggler.Loc
+    Smuggler.Parser
+    Smuggler.Plugin
 
-  build-depends:       bytestring ^>= 0.10
-                     , containers >= 0.5 && < 0.7
-                     , filepath ^>= 1.4
-                     , ghc ^>= 8.8.0
-                     , ghc-exactprint ^>= 0.6
-                     , unordered-containers ^>= 0.2.7
+  if flag(debug)
+    exposed-modules:
+      Smuggler.Debug
+-- Does not compile with 8.8.3      Smuggler.Import
+      Smuggler.Name
 
-                     -- Debug dependencies; in separate section to comment easily before release
---                      , fmt
---                      , pretty-simple
---                      , text
+  build-depends:
+    , bytestring            ^>=0.10
+    , containers            >=0.5   && <0.7
+    , filepath              ^>=1.4
+    , ghc                   ^>=8.8.0
+    , ghc-exactprint        ^>=0.6
+    , hashable              ^>=1.3
+    , unordered-containers  ^>=0.2.7
+
+  if flag(debug)
+    build-depends:
+      , fmt
+      , pretty-simple
+      , syb
+      , text
 
 executable play-smuggler
-  import:              common-options
-  hs-source-dirs:      app
-  main-is:             Main.hs
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
---                       -fplugin=Smuggler.Plugin
-  build-depends:       smuggler
+  import:         common-options
+  hs-source-dirs: app
+  main-is:        Main.hs
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+
+  if flag(debug)
+    ghc-options: -fplugin=Smuggler.Plugin
+
+  build-depends:  smuggler
 
 test-suite smuggler-test
-  import:              common-options
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
+  import:         common-options
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        Test.hs
+  other-modules:
+    Test.BoolBoolUnused
+    Test.BoolBoolUsed
+    Test.BoolPartlyUsedFirst
+    Test.BoolPartlyUsedLast
+    Test.ConstructorsUnused
+    Test.Dummy
+    Test.ImplicitImportUnused
+    Test.ImplicitImportUsed
+    Test.ImportEmpty
+    Test.MultilineUnused
+    Test.TypeConstructorUnused
+    Test.TypeConstructorUnusedComma
+    Test.TypeConstructorUsed
+    Test.TypeUnused
+    Test.TypeUsed
+    Test.WildcardUnused
+    Test.WildcardUsed
 
-  main-is:             Test.hs
-  other-modules:       Test.BoolBoolUsed
-                       Test.BoolBoolUnused
-                       Test.BoolPartlyUsedFirst
-                       Test.BoolPartlyUsedLast
-                       Test.ConstructorsUnused
-                       Test.Dummy
-                       Test.ImplicitImportUsed
-                       Test.ImplicitImportUnused
-                       Test.ImportEmpty
-                       Test.MultilineUnused
-                       Test.TypeConstructorUsed
-                       Test.TypeConstructorUnused
-                       Test.TypeConstructorUnusedComma
-                       Test.TypeUnused
-                       Test.TypeUsed
-                       Test.WildcardUsed
-                       Test.WildcardUnused
+  build-depends:
+    , ansi-terminal
+    , directory
+    , filepath
+    , smuggler
 
-  build-depends:       ansi-terminal
-                     , directory
-                     , filepath
-                     , smuggler
-
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-                       -fno-warn-unused-imports
-                       -fno-warn-missing-signatures
-                       -fplugin=Smuggler.Plugin
--- the plugin option suffixes the option name to create a new source file, rather than owerwriting the existing one
-                       -fplugin-opt=Smuggler.Plugin:test
+  ghc-options:
+    -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-imports
+    -fno-warn-missing-signatures -fplugin=Smuggler.Plugin
+    -fplugin-opt=Smuggler.Plugin:test

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -61,6 +61,7 @@ library
     Smuggler.Anns
     Smuggler.Exports
     Smuggler.Loc
+    Smuggler.Options
     Smuggler.Parser
     Smuggler.Plugin
 

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -76,6 +76,8 @@ library
     , containers      >=0.5   && <0.7
     , filepath        ^>=1.4
     , ghc             >=8.8.0
+    -- for GHC 8.10:
+    , ghc-api-compat
     , ghc-exactprint  ^>=0.6
     , syb
 

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -34,7 +34,7 @@ source-repository head
   location: git@github.com:kowainik/smuggler.git
 
 common common-options
-  build-depends:      base ^>=4.13
+  build-depends:      base >=4.13
   ghc-options:
     -Wall -Wextra -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wcompat -Widentities -Wredundant-constraints -fhide-source-paths

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -134,6 +134,10 @@ test-suite smuggler-test
   import:  common-tests
   type:    exitcode-stdio-1.0
   main-is: Test.hs
+  ghc-options:
+    -fplugin-opt=Smuggler.Plugin:test
+ --   -fplugin-opt=Smuggler.Plugin:NoExportProcessing
+ --    -fplugin-opt=Smuggler.Plugin:MinimiseImports
 
 test-suite smuggler-test-maximal
   import:  common-tests
@@ -142,4 +146,4 @@ test-suite smuggler-test-maximal
   ghc-options:
     -fplugin-opt=Smuggler.Plugin:test
     -fplugin-opt=Smuggler.Plugin:MinimiseImports
-    -fplugin-opt=Smuggler.Plugin:ReplaceExports
+--    -fplugin-opt=Smuggler.Plugin:ReplaceExports

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -59,6 +59,7 @@ library
   hs-source-dirs:  src
   exposed-modules:
     Smuggler.Anns
+    Smuggler.Exports
     Smuggler.Loc
     Smuggler.Parser
     Smuggler.Plugin
@@ -102,24 +103,26 @@ test-suite smuggler-test
   hs-source-dirs: test
   main-is:        Test.hs
   other-modules:
-    Test.BoolBoolUnused
-    Test.BoolBoolUsed
-    Test.BoolPartlyUsedFirst
-    Test.BoolPartlyUsedLast
-    Test.ConstructorsUnused
-    Test.Dummy
-    Test.ImplicitImportUnused
-    Test.ImplicitImportUsed
-    Test.ImportEmpty
-    Test.MultilineUnused
-    Test.TypeConstructorUnused
-    Test.TypeConstructorUnusedComma
-    Test.TypeConstructorUsed
-    Test.TypeUnused
-    Test.TypeUsed
-    Test.WildcardUnused
-    Test.WildcardUsed
+--    Test.BoolBoolUnused
+--    Test.BoolBoolUsed
+--    Test.BoolPartlyUsedFirst
+--    Test.BoolPartlyUsedLast
+--    Test.ConstructorsUnused
+--    Test.Dummy
+    Test.ExportExplicit
+    Test.ExportImplicit
+--    Test.ImplicitImportUnused
+--    Test.ImplicitImportUsed
+--    Test.ImportEmpty
+--    Test.MultilineUnused
+--    Test.TypeConstructorUnused
+--    Test.TypeConstructorUnusedComma
+--    Test.TypeConstructorUsed
+--    Test.TypeUnused
+--    Test.TypeUsed
+--    Test.WildcardUnused
 
+--
   build-depends:
     , ansi-terminal
     , directory

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -59,7 +59,8 @@ library
   hs-source-dirs:  src
   exposed-modules:
     Smuggler.Anns
-    Smuggler.Exports
+    Smuggler.Export
+    Smuggler.Import
     Smuggler.Loc
     Smuggler.Options
     Smuggler.Parser

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -75,7 +75,7 @@ library
   build-depends:
     , containers      >=0.5   && <0.7
     , filepath        ^>=1.4
-    , ghc             ^>=8.8.0
+    , ghc             >=8.8.0
     , ghc-exactprint  ^>=0.6
     , syb
 

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -102,24 +102,24 @@ common common-tests
   import:         common-options
   hs-source-dirs: test
   other-modules:
-    --Test.BoolBoolUnused
-    --Test.BoolBoolUsed
-    --Test.BoolPartlyUsedFirst
-    --Test.BoolPartlyUsedLast
-    --Test.ConstructorsUnused
-    --Test.Dummy
-    --Test.ExportExplicit
-    --Test.ExportImplicit
+    Test.BoolBoolUnused
+    Test.BoolBoolUsed
+    Test.BoolPartlyUsedFirst
+    Test.BoolPartlyUsedLast
+    Test.ConstructorsUnused
+    Test.Dummy
+    Test.ExportExplicit
+    Test.ExportImplicit
     Test.ImplicitImportUnused
-    --Test.ImplicitImportUsed
-    --Test.ImportEmpty
-    --Test.MultilineUnused
-    --Test.TypeConstructorUnused
-    --Test.TypeConstructorUnusedComma
-    --Test.TypeConstructorUsed
-    --Test.TypeUnused
-    --Test.TypeUsed
-    --Test.WildcardUnused
+    Test.ImplicitImportUsed
+    Test.ImportEmpty
+    Test.MultilineUnused
+    Test.TypeConstructorUnused
+    Test.TypeConstructorUnusedComma
+    Test.TypeConstructorUsed
+    Test.TypeUnused
+    Test.TypeUsed
+    Test.WildcardUnused
 
   build-depends:
     , ansi-terminal

--- a/smuggler.cabal
+++ b/smuggler.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                smuggler
-version:             0.2.0.0
+version:             0.2.0.1
 synopsis:            GHC Source Plugin that helps to manage imports
 description:
     == Usage
@@ -20,14 +20,14 @@ category:            Development, Refactoring
 build-type:          Simple
 extra-doc-files:     README.md
                      CHANGELOG.md
-tested-with:         GHC == 8.6.5
+tested-with:         GHC == 8.8.3
 
 source-repository head
   type:     git
   location: git@github.com:kowainik/smuggler.git
 
 common common-options
-  build-depends:       base ^>= 4.12
+  build-depends:       base ^>= 4.13
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns
                        -Wincomplete-record-updates
@@ -35,6 +35,7 @@ common common-options
                        -Widentities
                        -Wredundant-constraints
                        -fhide-source-paths
+                       -ddump-minimal-imports
 
   default-language:    Haskell2010
   default-extensions:  DeriveGeneric
@@ -62,7 +63,7 @@ library
   build-depends:       bytestring ^>= 0.10
                      , containers >= 0.5 && < 0.7
                      , filepath ^>= 1.4
-                     , ghc ^>= 8.6.0
+                     , ghc ^>= 8.8.0
                      , ghc-exactprint ^>= 0.6
                      , unordered-containers ^>= 0.2.7
 
@@ -112,4 +113,5 @@ test-suite smuggler-test
                        -fno-warn-unused-imports
                        -fno-warn-missing-signatures
                        -fplugin=Smuggler.Plugin
+-- the plugin option suffixes the option name to create a new source file, rather than owerwriting the existing one
                        -fplugin-opt=Smuggler.Plugin:test

--- a/src/Smuggler/Anns.hs
+++ b/src/Smuggler/Anns.hs
@@ -1,13 +1,19 @@
 module Smuggler.Anns
   ( removeAnnAtLoc
   , removeTrailingCommas
+  , removeLocatedKeywordT
   )
 where
 
-import           Data.List                      ( groupBy )
+import           Data.List                      ( find
+                                                , groupBy
+                                                )
 import qualified Data.Map.Strict               as Map
-                                                ( filterWithKey
+                                                ( delete
+                                                , filterWithKey
                                                 , fromList
+                                                , insert
+                                                , lookup
                                                 , toList
                                                 )
 import qualified GHC                            ( AnnKeywordId(AnnComma) )
@@ -15,56 +21,85 @@ import           Language.Haskell.GHC.ExactPrint
                                                 ( AnnKey(..)
                                                 , Annotation(..)
                                                 , Anns
+                                                , modifyAnnsT
+                                                , TransformT
                                                 )
 import           Language.Haskell.GHC.ExactPrint.Types
                                                 ( AnnConName(..)
                                                 , DeltaPos
                                                 , KeywordId(..)
+                                                , mkAnnKey
                                                 )
-import           SrcLoc                         ( SrcSpan(RealSrcSpan)
+import           SrcLoc                         ( Located
+                                                , SrcSpan(RealSrcSpan)
                                                 , srcSpanEndLine
                                                 , srcSpanStartCol
                                                 , srcSpanStartLine
                                                 )
 
+import           Data.Generics                 as SYB
 
 removeAnnAtLoc :: Int -> Int -> Anns -> Anns
 removeAnnAtLoc line col = Map.filterWithKey (\k _ -> matchKey k)
-  where
-    matchKey :: AnnKey -> Bool
-    matchKey (AnnKey (RealSrcSpan rss) _) =
-        not (srcSpanStartLine rss == line && srcSpanStartCol rss == col)
-    matchKey _ = True
+ where
+  matchKey :: AnnKey -> Bool
+  matchKey (AnnKey (RealSrcSpan rss) _) =
+    not (srcSpanStartLine rss == line && srcSpanStartCol rss == col)
+  matchKey _ = True
 
+removeLocatedKeywordT
+  :: (Data a, Monad m) => KeywordId -> Located a -> TransformT m ()
+removeLocatedKeywordT kw ast = modifyAnnsT (removeLocatedKeyword kw ast)
+
+removeLocatedKeyword :: (SYB.Data a) => KeywordId -> Located a -> Anns -> Anns
+removeLocatedKeyword kw ast anns = case Map.lookup (mkAnnKey ast) anns of
+  Nothing -> anns
+  Just an -> case find isKeyword (annsDP an) of
+    Nothing -> anns
+    Just _  -> Map.insert
+      (mkAnnKey ast)
+      (an { annsDP = filter (not . isKeyword) (annsDP an) })
+      anns
+   where
+    isKeyword (kw', _) | kw' == kw = True
+    isKeyword _                    = False
+
+-- Not needed; using the ghc-exactprint library version
 removeTrailingCommas :: Anns -> Anns
-removeTrailingCommas
-  = Map.fromList . concatMap removeIfImportDecl
-  . groupBy withinSrcSpan . Map.toList
-  where
-    removeIfImportDecl :: [(AnnKey, Annotation)] -> [(AnnKey, Annotation)]
-    removeIfImportDecl gAnns
-      | any isImportDecl gAnns = removeTrailingComma gAnns
-      | otherwise = gAnns
+removeTrailingCommas =
+  Map.fromList
+    . concatMap removeIfImportDecl
+    . groupBy withinSrcSpan
+    . Map.toList
+ where
+  removeIfImportDecl :: [(AnnKey, Annotation)] -> [(AnnKey, Annotation)]
+  removeIfImportDecl gAnns | any isImportDecl gAnns = removeTrailingComma gAnns
+                           | otherwise              = gAnns
 
-    removeTrailingComma :: [(AnnKey, Annotation)] -> [(AnnKey, Annotation)]
-    removeTrailingComma [] = []
-    -- The import anns are held in the shape of "(:) ... (IEName, IEVar, Unqual)"
-    -- we want to pattern match on the last entry and remove the list separator ','
-    -- if it is present
-    removeTrailingComma [x, (annKey, ann), z]
-      = [x, (annKey, ann { annsDP = filter (not . isTrailingComma) (annsDP ann) }), z]
-    removeTrailingComma (x : xs) = x : removeTrailingComma xs
+  removeTrailingComma :: [(AnnKey, Annotation)] -> [(AnnKey, Annotation)]
+  removeTrailingComma [] = []
+  -- The import anns are held in the shape of "(:) ... (IEName, IEVar, Unqual)"
+  -- we want to pattern match on the last entry and remove the list separator ','
+  -- if it is present
+  removeTrailingComma [x, (annKey, ann), z] =
+    [ x
+    , (annKey, ann { annsDP = filter (not . isTrailingComma) (annsDP ann) })
+    , z
+    ]
+  removeTrailingComma (x : xs) = x : removeTrailingComma xs
 
-    isImportDecl :: (AnnKey, Annotation) -> Bool
-    isImportDecl (AnnKey _ (CN "ImportDecl"), _) = True
-    isImportDecl _                               = False
+  isImportDecl :: (AnnKey, Annotation) -> Bool
+  isImportDecl (AnnKey _ (CN "ImportDecl"), _) = True
+  isImportDecl _                               = False
 
-    isTrailingComma :: (KeywordId, DeltaPos) -> Bool
-    isTrailingComma (G GHC.AnnComma, _) = True
-    isTrailingComma _                   = False
+  isTrailingComma :: (KeywordId, DeltaPos) -> Bool
+  isTrailingComma (G GHC.AnnComma, _) = True
+  isTrailingComma _                   = False
 
-    withinSrcSpan :: (AnnKey, Annotation) -> (AnnKey, Annotation) -> Bool
-    withinSrcSpan (AnnKey (RealSrcSpan x) _, _) (AnnKey (RealSrcSpan y) _, _)
-      = srcSpanStartLine x == srcSpanStartLine y
-      || srcSpanEndLine x == srcSpanEndLine y
-    withinSrcSpan _ _ = True
+  withinSrcSpan :: (AnnKey, Annotation) -> (AnnKey, Annotation) -> Bool
+  withinSrcSpan (AnnKey (RealSrcSpan x) _, _) (AnnKey (RealSrcSpan y) _, _) =
+    srcSpanStartLine x
+      == srcSpanStartLine y
+      || srcSpanEndLine x
+      == srcSpanEndLine y
+  withinSrcSpan _ _ = True

--- a/src/Smuggler/Anns.hs
+++ b/src/Smuggler/Anns.hs
@@ -1,15 +1,32 @@
 module Smuggler.Anns
-       ( removeAnnAtLoc
-       , removeTrailingCommas
-       ) where
+  ( removeAnnAtLoc
+  , removeTrailingCommas
+  )
+where
 
-import Data.List (groupBy)
-import Language.Haskell.GHC.ExactPrint (AnnKey (..), Annotation (..), Anns)
-import Language.Haskell.GHC.ExactPrint.Types (AnnConName (..), DeltaPos, KeywordId (..))
-import SrcLoc (SrcSpan (RealSrcSpan), srcSpanStartCol, srcSpanStartLine, srcSpanEndLine)
+import           Data.List                      ( groupBy )
+import qualified Data.Map.Strict               as Map
+                                                ( filterWithKey
+                                                , fromList
+                                                , toList
+                                                )
+import qualified GHC                            ( AnnKeywordId(AnnComma) )
+import           Language.Haskell.GHC.ExactPrint
+                                                ( AnnKey(..)
+                                                , Annotation(..)
+                                                , Anns
+                                                )
+import           Language.Haskell.GHC.ExactPrint.Types
+                                                ( AnnConName(..)
+                                                , DeltaPos
+                                                , KeywordId(..)
+                                                )
+import           SrcLoc                         ( SrcSpan(RealSrcSpan)
+                                                , srcSpanEndLine
+                                                , srcSpanStartCol
+                                                , srcSpanStartLine
+                                                )
 
-import qualified Data.Map.Strict as Map
-import qualified GHC
 
 removeAnnAtLoc :: Int -> Int -> Anns -> Anns
 removeAnnAtLoc line col = Map.filterWithKey (\k _ -> matchKey k)
@@ -40,11 +57,11 @@ removeTrailingCommas
 
     isImportDecl :: (AnnKey, Annotation) -> Bool
     isImportDecl (AnnKey _ (CN "ImportDecl"), _) = True
-    isImportDecl _ = False
+    isImportDecl _                               = False
 
     isTrailingComma :: (KeywordId, DeltaPos) -> Bool
     isTrailingComma (G GHC.AnnComma, _) = True
-    isTrailingComma _ = False
+    isTrailingComma _                   = False
 
     withinSrcSpan :: (AnnKey, Annotation) -> (AnnKey, Annotation) -> Bool
     withinSrcSpan (AnnKey (RealSrcSpan x) _, _) (AnnKey (RealSrcSpan y) _, _)

--- a/src/Smuggler/Debug.hs
+++ b/src/Smuggler/Debug.hs
@@ -3,18 +3,28 @@
 {-# LANGUAGE TypeApplications    #-}
 
 module Smuggler.Debug
-       ( debugAST
-       ) where
+  ( debugAST
+  )
+where
 
-import Data.Proxy (Proxy (..))
-import Data.Text (Text)
-import Data.Text.Lazy (toStrict)
-import Data.Typeable (Typeable, typeRep)
-import Fmt (fmt, padLeftF)
-import Text.Pretty.Simple (pShow)
+import           Data.Proxy                     ( Proxy(..) )
+import           Data.Text                      ( Text )
+import           Data.Text.Lazy                 ( toStrict )
+import           Data.Typeable                  ( Typeable
+                                                , typeRep
+                                                )
+import           Fmt                            ( fmt
+                                                , padLeftF
+                                                )
+import           Text.Pretty.Simple             ( pShow )
+import qualified Data.Text                     as T
+                                                ( lines
+                                                , pack
+                                                , unlines
+                                                )
+import qualified Data.Text.IO                  as T
+                                                ( putStrLn )
 
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
 
 -- | Helper function to debug different parts of AST processing.
 {-# WARNING debugAST "'debugAST' remains in code" #-}

--- a/src/Smuggler/Export.hs
+++ b/src/Smuggler/Export.hs
@@ -1,15 +1,51 @@
 module Smuggler.Export where
 
-import Avail (AvailInfo, availNamesWithSelectors)
-import Debug.Trace (traceM)
-import GHC (AnnKeywordId (..), GenLocated (..), IE (..), IEWrappedName (..), Located, Name)
-import Language.Haskell.GHC.ExactPrint.Transform (TransformT, addSimpleAnnT, uniqueSrcSpanT)
-import Language.Haskell.GHC.ExactPrint.Types (DeltaPos (DP), GhcPs, KeywordId (G), noExt)
-import OccName (HasOccName (occName), OccName (occNameFS))
-import RdrName (mkVarUnqual)
+import Control.Monad ( unless )
+import DynFlags ( DynFlags )
+import Avail ( AvailInfo, availNamesWithSelectors )
+import Debug.Trace ()
+import GHC
+    ( AnnKeywordId(..),
+      GenLocated(..),
+      IE(..),
+      IEWrappedName(..),
+      Located,
+      Name,
+      HsModule,
+      hsmodExports )
+import Language.Haskell.GHC.ExactPrint.Transform
+    ( TransformT, addSimpleAnnT, uniqueSrcSpanT, runTransform )
+import Language.Haskell.GHC.ExactPrint.Types
+    ( Anns, DeltaPos(DP), GhcPs, KeywordId(G), noExt )
+import OccName ( HasOccName(occName), OccName(occNameFS) )
+import RdrName ( mkVarUnqual )
+
 
 -- See https://www.machinesung.com/scribbles/terser-import-declarations.html
 -- and https://www.machinesung.com/scribbles/ghc-api.html
+
+
+addExplicitExports
+  :: DynFlags
+  -> [AvailInfo]
+  -> (Anns, Located (HsModule GhcPs))
+  -> (Anns, Located (HsModule GhcPs))
+addExplicitExports dflags exports (anns, L astLoc hsMod) = (anns', ast')
+ where
+  (ast', (anns', _n), _s) = runTransform anns $ do
+
+    let names = mkNamesFromAvailInfos exports
+
+    exportsList <- mapM mkIEVarFromNameT names
+    mapM_ addExportDeclAnnT exportsList
+    unless (null exportsList) $ mapM_ addCommaT (init exportsList)
+
+    let lExportsList = L astLoc exportsList
+        hsMod'       = hsMod { hsmodExports = Just lExportsList }
+    addParensT lExportsList
+
+    return (L astLoc hsMod')
+
 
 mkNamesFromAvailInfos :: [AvailInfo] -> [Name]
 mkNamesFromAvailInfos = concatMap availNamesWithSelectors
@@ -20,19 +56,17 @@ mkIEVarFromNameT :: Monad m => Name -> TransformT m (Located (IE GhcPs))
 mkIEVarFromNameT name = do
   -- Could use only one loc as it would be used on different constructors
   -- and not, therefore, get overwritten on subsequent uses.
-  locIEVar <- uniqueSrcSpanT
+  locIEVar  <- uniqueSrcSpanT
   locIEName <- uniqueSrcSpanT
   locUnqual <- uniqueSrcSpanT
-  return $
-    L
-      locIEVar
-      ( IEVar
-          noExt
-          ( L
-              locIEName
-              (IEName (L locUnqual (mkVarUnqual ((occNameFS . occName) name))))
-          )
+  return $ L
+    locIEVar
+    (IEVar
+      noExt
+      (L locIEName
+         (IEName (L locUnqual (mkVarUnqual ((occNameFS . occName) name))))
       )
+    )
 
 addExportDeclAnnT :: Monad m => Located (IE GhcPs) -> TransformT m ()
 addExportDeclAnnT (L _ (IEVar _ (L _ (IEName x)))) =
@@ -42,8 +76,7 @@ addCommaT :: Monad m => Located (IE GhcPs) -> TransformT m ()
 addCommaT x = addSimpleAnnT x (DP (0, 0)) [(G AnnComma, DP (0, 0))]
 
 addParensT :: Monad m => Located [Located (IE GhcPs)] -> TransformT m ()
-addParensT x =
-  addSimpleAnnT
-    x
-    (DP (0, 1))
-    [(G AnnOpenP, DP (0, 0)), (G AnnCloseP, DP (0, 1))]
+addParensT x = addSimpleAnnT
+  x
+  (DP (0, 1))
+  [(G AnnOpenP, DP (0, 0)), (G AnnCloseP, DP (0, 1))]

--- a/src/Smuggler/Export.hs
+++ b/src/Smuggler/Export.hs
@@ -1,4 +1,4 @@
-module Smuggler.Exports where
+module Smuggler.Export where
 
 import Avail (AvailInfo, availNamesWithSelectors)
 import Debug.Trace (traceM)

--- a/src/Smuggler/Exports.hs
+++ b/src/Smuggler/Exports.hs
@@ -1,6 +1,6 @@
 module Smuggler.Exports where
 
-import Avail (AvailInfo, availNames)
+import Avail (AvailInfo, availNamesWithSelectors)
 import Debug.Trace (traceM)
 import GHC (AnnKeywordId (..), GenLocated (..), IE (..), IEWrappedName (..), Located, Name)
 import Language.Haskell.GHC.ExactPrint.Transform (TransformT, addSimpleAnnT, uniqueSrcSpanT)
@@ -12,7 +12,9 @@ import RdrName (mkVarUnqual)
 -- and https://www.machinesung.com/scribbles/ghc-api.html
 
 mkNamesFromAvailInfos :: [AvailInfo] -> [Name]
-mkNamesFromAvailInfos = concatMap availNames -- there are also other choices
+mkNamesFromAvailInfos = concatMap availNamesWithSelectors
+--Produces all  names made available by the availability information (including overloaded selectors)
+--To exclude overloaded selector use availNames
 
 mkIEVarFromNameT :: Monad m => Name -> TransformT m (Located (IE GhcPs))
 mkIEVarFromNameT name = do

--- a/src/Smuggler/Exports.hs
+++ b/src/Smuggler/Exports.hs
@@ -1,0 +1,43 @@
+module Smuggler.Exports where
+
+import           GHC                            ( AnnKeywordId(..)
+                                                , IEWrappedName(..)
+                                                , Name
+                                                , Located
+                                                , GenLocated(..)
+                                                , IE(..)
+                                                )
+import           Language.Haskell.GHC.ExactPrint.Transform
+import           RdrName
+import           OccName
+import           Language.Haskell.GHC.ExactPrint.Types
+
+import           Avail
+
+import Debug.Trace
+
+-- See https://www.machinesung.com/scribbles/terser-import-declarations.html
+-- and https://www.machinesung.com/scribbles/ghc-api.html
+
+
+
+mkNamesFromAvailInfos :: [AvailInfo] -> [Name]
+mkNamesFromAvailInfos = concatMap availNames -- there are also other choices
+
+mkIEVarFromNameT :: Monad m => Name -> TransformT m (Located (IE GhcPs))
+mkIEVarFromNameT name = do
+  loc <- uniqueSrcSpanT
+  traceM $ "loc: " ++ show loc
+  return $ L
+    loc
+    (IEVar noExt
+           (L loc (IEName (L loc (mkVarUnqual ((occNameFS . occName) name)))))
+    )
+
+addExportDeclAnnT :: Monad m => Located (IE GhcPs) -> TransformT m ()
+addExportDeclAnnT (L _ (IEVar _ (L _ (IEName x)))) =
+  addSimpleAnnT x (DP (1, 2)) [(G AnnVal, DP (0, 0))]
+
+addCommaT :: Monad m => Located (IE GhcPs) -> TransformT m ()
+addCommaT x@(L _ (IEVar _ (L _ (IEName _)))) =
+  addSimpleAnnT x (DP (0, 0)) [(G AnnComma, DP (0, 0))]

--- a/src/Smuggler/Exports.hs
+++ b/src/Smuggler/Exports.hs
@@ -16,6 +16,8 @@ mkNamesFromAvailInfos = concatMap availNames -- there are also other choices
 
 mkIEVarFromNameT :: Monad m => Name -> TransformT m (Located (IE GhcPs))
 mkIEVarFromNameT name = do
+  -- Could use only one loc as it would be used on different constructors
+  -- and not, therefore, get overwritten on subsequent uses.
   locIEVar <- uniqueSrcSpanT
   locIEName <- uniqueSrcSpanT
   locUnqual <- uniqueSrcSpanT

--- a/src/Smuggler/Exports.hs
+++ b/src/Smuggler/Exports.hs
@@ -8,8 +8,6 @@ import Language.Haskell.GHC.ExactPrint.Types (DeltaPos (DP), GhcPs, KeywordId (G
 import OccName (HasOccName (occName), OccName (occNameFS))
 import RdrName (mkVarUnqual)
 
-
-
 -- See https://www.machinesung.com/scribbles/terser-import-declarations.html
 -- and https://www.machinesung.com/scribbles/ghc-api.html
 
@@ -19,12 +17,13 @@ mkNamesFromAvailInfos = concatMap availNames -- there are also other choices
 mkIEVarFromNameT :: Monad m => Name -> TransformT m (Located (IE GhcPs))
 mkIEVarFromNameT name = do
   loc <- uniqueSrcSpanT
-  traceM $ "loc: " ++ show loc
-  return $ L
-    loc
-    (IEVar noExt
-           (L loc (IEName (L loc (mkVarUnqual ((occNameFS . occName) name)))))
-    )
+  return $
+    L
+      loc
+      ( IEVar
+          noExt
+          (L loc (IEName (L loc (mkVarUnqual ((occNameFS . occName) name)))))
+      )
 
 addExportDeclAnnT :: Monad m => Located (IE GhcPs) -> TransformT m ()
 addExportDeclAnnT (L _ (IEVar _ (L _ (IEName x)))) =
@@ -34,7 +33,8 @@ addCommaT :: Monad m => Located (IE GhcPs) -> TransformT m ()
 addCommaT x = addSimpleAnnT x (DP (0, 0)) [(G AnnComma, DP (0, 0))]
 
 addParensT :: Monad m => Located [Located (IE GhcPs)] -> TransformT m ()
-addParensT x = addSimpleAnnT
-  x
-  (DP (0, 1))
-  [(G AnnOpenP, DP (0, 0)), (G AnnCloseP, DP (0, 1))]
+addParensT x =
+  addSimpleAnnT
+    x
+    (DP (0, 1))
+    [(G AnnOpenP, DP (0, 0)), (G AnnCloseP, DP (0, 1))]

--- a/src/Smuggler/Exports.hs
+++ b/src/Smuggler/Exports.hs
@@ -1,25 +1,17 @@
 module Smuggler.Exports where
 
-import           GHC                            ( AnnKeywordId(..)
-                                                , IEWrappedName(..)
-                                                , Name
-                                                , Located
-                                                , GenLocated(..)
-                                                , IE(..)
-                                                )
-import           Language.Haskell.GHC.ExactPrint.Transform
-import           RdrName
-import           OccName
-import           Language.Haskell.GHC.ExactPrint.Types
+import Avail (AvailInfo, availNames)
+import Debug.Trace (traceM)
+import GHC (AnnKeywordId (..), GenLocated (..), IE (..), IEWrappedName (..), Located, Name)
+import Language.Haskell.GHC.ExactPrint.Transform (TransformT, addSimpleAnnT, uniqueSrcSpanT)
+import Language.Haskell.GHC.ExactPrint.Types (DeltaPos (DP), GhcPs, KeywordId (G), noExt)
+import OccName (HasOccName (occName), OccName (occNameFS))
+import RdrName (mkVarUnqual)
 
-import           Avail
 
-import Debug.Trace
 
 -- See https://www.machinesung.com/scribbles/terser-import-declarations.html
 -- and https://www.machinesung.com/scribbles/ghc-api.html
-
-
 
 mkNamesFromAvailInfos :: [AvailInfo] -> [Name]
 mkNamesFromAvailInfos = concatMap availNames -- there are also other choices
@@ -39,5 +31,10 @@ addExportDeclAnnT (L _ (IEVar _ (L _ (IEName x)))) =
   addSimpleAnnT x (DP (1, 2)) [(G AnnVal, DP (0, 0))]
 
 addCommaT :: Monad m => Located (IE GhcPs) -> TransformT m ()
-addCommaT x@(L _ (IEVar _ (L _ (IEName _)))) =
-  addSimpleAnnT x (DP (0, 0)) [(G AnnComma, DP (0, 0))]
+addCommaT x = addSimpleAnnT x (DP (0, 0)) [(G AnnComma, DP (0, 0))]
+
+addParensT :: Monad m => Located [Located (IE GhcPs)] -> TransformT m ()
+addParensT x = addSimpleAnnT
+  x
+  (DP (0, 1))
+  [(G AnnOpenP, DP (0, 0)), (G AnnCloseP, DP (0, 1))]

--- a/src/Smuggler/Exports.hs
+++ b/src/Smuggler/Exports.hs
@@ -16,13 +16,18 @@ mkNamesFromAvailInfos = concatMap availNames -- there are also other choices
 
 mkIEVarFromNameT :: Monad m => Name -> TransformT m (Located (IE GhcPs))
 mkIEVarFromNameT name = do
-  loc <- uniqueSrcSpanT
+  locIEVar <- uniqueSrcSpanT
+  locIEName <- uniqueSrcSpanT
+  locUnqual <- uniqueSrcSpanT
   return $
     L
-      loc
+      locIEVar
       ( IEVar
           noExt
-          (L loc (IEName (L loc (mkVarUnqual ((occNameFS . occName) name)))))
+          ( L
+              locIEName
+              (IEName (L locUnqual (mkVarUnqual ((occNameFS . occName) name))))
+          )
       )
 
 addExportDeclAnnT :: Monad m => Located (IE GhcPs) -> TransformT m ()

--- a/src/Smuggler/Import.hs
+++ b/src/Smuggler/Import.hs
@@ -1,60 +1,97 @@
 module Smuggler.Import where
 
-import Control.Monad (guard)
-import qualified Data.HashMap.Strict as HashMap ()
+import Control.Monad ( guard )
+import HsSyn ( GhcRn )
+import Name ( Name, nameSrcSpan )
+import PrelNames ( pRELUDE_NAME )
+import RnNames ( ImportDeclUsage, findImportUsage )
+import Smuggler.Options ( ImportAction(..) )
+import Smuggler.Anns ( removeAnnAtLoc, removeTrailingCommas )
+import Data.List ( foldl' )
+import DynFlags ( DynFlags )
+import RdrName ( GlobalRdrElt )
 import HsImpExp
-  ( IE (IEThingAbs, IEThingAll, IEThingWith, IEVar),
-    IEWrappedName (IEName),
-    ImportDecl (ideclHiding, ideclName),
-    LIE,
-    LIEWrappedName,
-  )
-import HsSyn (GhcRn)
-import Name (Name, nameSrcSpan)
-import PrelNames (pRELUDE_NAME)
-import RnNames (ImportDeclUsage)
+    ( IE(IEThingWith, IEVar, IEThingAbs, IEThingAll),
+      IEWrappedName(IEName),
+      ImportDecl(ideclName, ideclHiding),
+      LIE,
+      LIEWrappedName,
+      LImportDecl )
+import Language.Haskell.GHC.ExactPrint.Types ( Anns )
 import SrcLoc
-  ( GenLocated (L),
-    SrcSpan (RealSrcSpan, UnhelpfulSpan),
-    srcSpanEndCol,
-    srcSpanStartCol,
-    srcSpanStartLine,
-    unLoc,
-  )
+    ( SrcSpan(..),
+      Located,
+      srcSpanEndCol,
+      srcSpanEndLine,
+      srcSpanStartCol,
+      srcSpanStartLine,
+      unLoc,
+      GenLocated(L) )
+import GHC ( HsModule, GhcPs )
 
+minimiseImports
+  :: DynFlags
+  -> ImportAction
+  -> [LImportDecl GhcRn]
+  -> [GlobalRdrElt]
+  -> (Anns, Located (HsModule GhcPs))
+  -> (Anns, Located (HsModule GhcPs))
+minimiseImports dflags action user_imports uses p@(anns, ast) = case action of
+  NoImportProcessing -> p
+  _ -> if null unusedPositions then p else (purifiedAnnotations, ast)
+ where
+  usage :: [ImportDeclUsage]
+  usage = findImportUsage user_imports uses
+
+  unusedPositions :: [(Int, Int)]
+  unusedPositions = concatMap (unusedLocs action) usage
+
+  purifiedAnnotations :: Anns
+  purifiedAnnotations = removeTrailingCommas -- Does removeTrailing commas work on []? If so simplify above
+    $ foldl' (\ann (x, y) -> removeAnnAtLoc x y ann) -- this seems a bit scattergun
+                                                     anns unusedPositions
 
 -- TODO: rewrite this as a transform, like Export
 
 -- TODO: reuse more logic from GHC. Is it possible?
-unusedLocs :: ImportDeclUsage -> [(Int, Int)]
-unusedLocs (L (UnhelpfulSpan _) _, _, _) = []
-unusedLocs (L (RealSrcSpan loc) decl, used, unused)
+unusedLocs :: ImportAction -> ImportDeclUsage -> [(Int, Int)]
+unusedLocs _ (L (UnhelpfulSpan _) _, _, _) = []
+unusedLocs action (L (RealSrcSpan loc) decl, used, unused)
   | -- Do not remove `import M ()`
     Just (False, L _ []) <- ideclHiding decl
   = []
+
   | -- Note [Do not warn about Prelude hiding]
     -- TODO: add ability to support custom prelude
     Just (True, L _ hides) <- ideclHiding decl
   , not (null hides)
   , pRELUDE_NAME == unLoc (ideclName decl)
   = []
-  | {-
-        This is is not always correct, because instances may be imported
-        as in first case above
-    
-        -- Nothing used; drop entire decl
-        | null used = [ (lineNum, colNum)
-                      | lineNum <- [srcSpanStartLine loc .. srcSpanEndLine loc]
-                      , colNum <-  [srcSpanStartCol loc .. getEndColMax unused]
-                      ]
-    -}
 
-    -- Everything imported is used; drop nothing
-    null unused
-  = []
   | -- only part of non-hiding import is used
     Just (False, L _ lies) <- ideclHiding decl
   = unusedLies lies
+
+  | -- Nothing used
+    null used
+  = case action of
+    PreserveInstanceImports ->
+      case ideclHiding decl of
+        Nothing -> [] -- ?
+        Just (True, _) -> [] -- TODO: deal with unused hidings
+        Just (False, L _ lies) -> unusedLies lies
+    MinimiseImports ->
+      -- Drop entire decl
+      [ (lineNum, colNum)
+      | lineNum <- [srcSpanStartLine loc .. srcSpanEndLine loc]
+      , colNum  <- [srcSpanStartCol loc .. getEndColMax unused]
+      ]
+    NoImportProcessing -> error "Processing imports, when should not be doing so"
+
+  | -- Everything imported is used; drop nothing
+    null unused
+  = []
+
   | -- TODO: unused hidings
     otherwise
   = []

--- a/src/Smuggler/Import.hs
+++ b/src/Smuggler/Import.hs
@@ -1,35 +1,76 @@
 module Smuggler.Import where
 
-import Control.Monad ( guard )
-import HsSyn ( GhcRn )
-import Name ( Name, nameSrcSpan )
-import PrelNames ( pRELUDE_NAME )
-import RnNames ( ImportDeclUsage, findImportUsage )
-import Smuggler.Options ( ImportAction(..) )
-import Smuggler.Anns ( removeAnnAtLoc, removeTrailingCommas )
-import Data.List ( foldl' )
-import DynFlags ( DynFlags )
-import RdrName ( GlobalRdrElt )
-import HsImpExp
-    ( IE(IEThingWith, IEVar, IEThingAbs, IEThingAll),
-      IEWrappedName(IEName),
-      ImportDecl(ideclName, ideclHiding),
-      LIE,
-      LIEWrappedName,
-      LImportDecl )
-import Language.Haskell.GHC.ExactPrint.Types ( Anns )
-import SrcLoc
-    ( SrcSpan(..),
-      Located,
-      srcSpanEndCol,
-      srcSpanEndLine,
-      srcSpanStartCol,
-      srcSpanStartLine,
-      unLoc,
-      GenLocated(L) )
-import GHC ( HsModule, GhcPs )
+import           Control.Monad                  ( guard )
+import           HsSyn                          ( GhcRn )
+import           Name                           ( Name
+                                                , nameSrcSpan
+                                                )
+import           PrelNames                      ( pRELUDE_NAME )
+import           RnNames                        ( ImportDeclUsage
+                                                , findImportUsage
+                                                , getMinimalImports
+                                                )
+import           Smuggler.Options               ( ImportAction(..) )
+import           Smuggler.Anns                  ( removeAnnAtLoc
+                                                , removeTrailingCommas
+                                                )
+import           Data.List                      ( foldl' )
+import           DynFlags                       ( DynFlags )
+import           RdrName                        ( GlobalRdrElt )
+import           HsImpExp                       ( ideclImplicit
+                                                , ieLWrappedName
+                                                , IE
+                                                  ( IEThingWith
+                                                  , IEVar
+                                                  , IEThingAbs
+                                                  , IEThingAll
+                                                  )
+                                                , IEWrappedName(IEName)
+                                                , ImportDecl
+                                                  ( ideclName
+                                                  , ideclHiding
+                                                  )
+                                                , LIE
+                                                , LIEWrappedName
+                                                , LImportDecl
+                                                )
+import           Language.Haskell.GHC.ExactPrint.Types
+                                                ( Anns )
+import           SrcLoc                         ( SrcSpan(..)
+                                                , Located
+                                                , srcSpanEndCol
+                                                , srcSpanEndLine
+                                                , srcSpanStartCol
+                                                , srcSpanStartLine
+                                                , unLoc
+                                                , GenLocated(L)
+                                                )
+import           GHC                            ( AnnKeywordId(..)
+                                                , HsModule
+                                                , GhcPs
+                                                , hsmodImports
+                                                )
+import           Language.Haskell.GHC.ExactPrint.Transform
+                                                ( TransformT
+                                                , addSimpleAnnT
+                                                , runTransform
+                                                , uniqueSrcSpanT
+                                                )
+import           Outputable
+import           TcRnTypes
+import           Avail
+import           LoadIface
+import           BasicTypes
+import           Language.Haskell.GHC.ExactPrint.Utils
+                                                ( ss2posEnd, debug )
+import           Language.Haskell.GHC.ExactPrint.Types
+                                                ( Anns
+                                                , DeltaPos(DP)
+                                                , KeywordId(G)
+                                                , noExt
+                                                )
+import Language.Haskell.GHC.ExactPrint.Print (exactPrint)
 
-import Outputable
 
 minimiseImports
   :: DynFlags
@@ -43,61 +84,80 @@ minimiseImports dflags action user_imports uses p@(anns, ast) = case action of
   _                  -> (purifiedAnnotations, ast)
  where
   usage :: [ImportDeclUsage]
-  usage = findImportUsage user_imports uses
+  usage                    = findImportUsage user_imports uses
 
-  unusedPositions :: [(Int, Int)]
-  unusedPositions = concatMap (unusedLocs dflags action) usage
+  (anns', unusedPositions) = findUnusedLocs anns usage
+
+  findUnusedLocs :: Anns -> [ImportDeclUsage] -> (Anns, [(Int, Int)])
+  findUnusedLocs anns []       = (anns, [])
+  findUnusedLocs anns (u : us) = (anns'', unusedPositions ++ unusedPositions')
+   where
+    (anns' , unusedPositions ) = unusedLocs dflags action anns u
+    (anns'', unusedPositions') = findUnusedLocs anns' us
+
 
   purifiedAnnotations :: Anns
   purifiedAnnotations = removeTrailingCommas -- Does removeTrailing commas work on []? If so simplify above
     $ foldl' (\ann (x, y) -> removeAnnAtLoc x y ann) -- this seems a bit scattergun
-                                                     anns unusedPositions
+                                                     anns' unusedPositions
 
--- TODO: rewrite this as a transform, like Export
+-- TODO: rewrite this as a transform, like Export?
 
 -- TODO: reuse more logic from GHC. Is it possible?
-unusedLocs :: DynFlags -> ImportAction -> ImportDeclUsage -> [(Int, Int)]
-unusedLocs _ _ (L (UnhelpfulSpan _) _, _, _) = []
-unusedLocs dynflags action (L (RealSrcSpan loc) decl, used, unused)
+unusedLocs
+  :: DynFlags -> ImportAction -> Anns -> ImportDeclUsage -> (Anns, [(Int, Int)])
+unusedLocs _ _ anns (L (UnhelpfulSpan _) _, _, _) = (anns, [])
+unusedLocs dynflags action anns (imp@(L (RealSrcSpan loc) decl), used, unused)
   | -- Do not remove `import M ()`
     Just (False, L _ []) <- ideclHiding decl
-  = []
+  = (anns, [])
   | -- Note [Do not warn about Prelude hiding]
     -- TODO: add ability to support custom prelude
     Just (True, L _ hides) <- ideclHiding decl
   , not (null hides)
-  , pRELUDE_NAME == unLoc (ideclName decl)
-  = []
-{-
+  , ideclImplicit decl -- pRELUDE_NAME == unLoc (ideclName decl)
+  = (anns, [])
   | -- Nothing used
     null used
   = case action of
     PreserveInstanceImports -> case ideclHiding decl of
-      Nothing -> trace ("Nothing:\ndecl: " ++ showSDoc dynflags (ppr decl)
-           ++ " used: " ++ showSDoc dynflags (ppr used)
-           ++ " unused: " ++ showSDoc dynflags (ppr unused)
-           ) []
---      Nothing -> error " Yuk"
-      Just (True , _       ) -> [] -- TODO: deal with unused hidings
-      Just (False, L _ lies) -> unusedLies lies
+--      Nothing -> trace ("Nothing:\ndecl: " ++ showSDoc dynflags (ppr decl)
+--           ++ " used: " ++ showSDoc dynflags (ppr used)
+--           ++ " unused: " ++ showSDoc dynflags (ppr unused)
+--           ) []
+      Nothing -> 
+
+        -- This isn't enough;  need also to mod iDeclHiding decl
+        let (_ast, (anns', _n), _s) = runTransform anns $ do
+              addSimpleAnnT
+                imp
+                (DP (0, 0))
+                [(G AnnOpenP,DP (0,0)),(G AnnCloseP,DP (0,0))]
+
+        in  (anns', []) 
+
+
+      Just (True , _       ) -> (anns, []) -- TODO: deal with unused hidings
+      Just (False, L _ lies) -> (anns, unusedLies lies)
     MinimiseImports ->
+      ( anns
+      ,
       -- Drop entire decl
-      [ (lineNum, colNum)
-      | lineNum <- [srcSpanStartLine loc .. srcSpanEndLine loc]
-      , colNum  <- [srcSpanStartCol loc .. getEndColMax unused]
-      ]
+        [ (lineNum, colNum)
+        | lineNum <- [srcSpanStartLine loc .. srcSpanEndLine loc]
+        , colNum <- [srcSpanStartCol loc .. getEndColMax unused]
+        ]
+      )
     NoImportProcessing ->
       error "Processing imports, when should not be doing so"
--}
-  | null unused = [] -- Everything imported is used; drop nothing
-
-  | -- only part of non-hiding import is used
+  | null unused
+  = (anns, [])
+  | -- Everything imported is used; drop nothing -- only part of non-hiding import is used
     Just (False, L _ lies) <- ideclHiding decl
-  = unusedLies lies
-
+  = (anns, unusedLies lies)
   | -- TODO: unused hidings
     otherwise
-  = []
+  = (anns, [])
  where
   unusedLies :: [LIE GhcRn] -> [(Int, Int)]
   unusedLies = concatMap lieToLoc
@@ -112,16 +172,16 @@ unusedLocs dynflags action (L (RealSrcSpan loc) decl, used, unused)
 
   lieNameToLoc :: LIEWrappedName Name -> [(Int, Int)]
   lieNameToLoc lieName = do
-    L _ (IEName (L (RealSrcSpan lieLoc) name)) <- [lieName]
+    L lieLoc name <- [ieLWrappedName lieName]
     guard $ name `elem` unused
-    pure (srcSpanStartLine lieLoc, srcSpanStartCol lieLoc)
+    pure (ss2posEnd lieLoc)
 
   getEndColMax :: [Name] -> Int
-  getEndColMax u = listMax $ map (findColLoc . nameSrcSpan) u
+  getEndColMax u = listMax $ map (srcSpanEndColumn' . nameSrcSpan) u
 
-  findColLoc :: SrcSpan -> Int
-  findColLoc (RealSrcSpan   l) = srcSpanEndCol l
-  findColLoc (UnhelpfulSpan _) = defaultCol
+  srcSpanEndColumn' :: SrcSpan -> Int
+  srcSpanEndColumn' (RealSrcSpan   l) = srcSpanEndCol l
+  srcSpanEndColumn' (UnhelpfulSpan _) = defaultCol
 
 defaultCol :: Int
 defaultCol = 120
@@ -130,3 +190,37 @@ listMax :: [Int] -> Int
 listMax []           = defaultCol
 listMax [x         ] = x
 listMax (x : y : xs) = listMax ((if x >= y then x else y) : xs)
+
+
+
+
+removeSurplusImports
+  :: DynFlags
+  -> ImportAction
+  -> [LImportDecl GhcRn]
+  -> [GlobalRdrElt]
+  -> (Anns, Located (HsModule GhcPs))
+  -> (Anns, Located (HsModule GhcPs))
+removeSurplusImports dflags action user_imports uses p@(anns, L astLoc hsMod) =
+  case action of
+    NoImportProcessing -> p
+    _                  -> (anns', ast')
+ where
+  usage :: [ImportDeclUsage] -- [(LImportDecl GhcRn, used: [AvailInfo], unused: [Name])]
+  usage = findImportUsage user_imports uses
+
+  minimalUsage :: RnM [LImportDecl GhcRn]
+  minimalUsage            = getMinimalImports usage
+
+     --  - 'ApiAnnotation.AnnOpen', 'ApiAnnotation.AnnClose' for ideclSource
+
+     --  - 'ApiAnnotation.AnnHiding','ApiAnnotation.AnnOpen',
+     --    'ApiAnnotation.AnnClose' attached
+     --     to location in ideclHiding
+
+  (ast', (anns', _n), _s) = runTransform anns $ do
+
+    let hsMod' = hsMod { hsmodImports = hsmodImports hsMod }
+    return (L astLoc hsMod')
+
+

--- a/src/Smuggler/Import.hs
+++ b/src/Smuggler/Import.hs
@@ -22,6 +22,9 @@ import SrcLoc
     unLoc,
   )
 
+
+-- TODO: rewrite this as a transform, like Export
+
 -- TODO: reuse more logic from GHC. Is it possible?
 unusedLocs :: ImportDeclUsage -> [(Int, Int)]
 unusedLocs (L (UnhelpfulSpan _) _, _, _) = []

--- a/src/Smuggler/Import.hs
+++ b/src/Smuggler/Import.hs
@@ -1,8 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-{-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 
 module Smuggler.Import
        ( Import (..)
@@ -82,7 +80,7 @@ getLocationMap :: (Eq name) => HsModule name -> HashMap (Import name) SrcSpan
 getLocationMap HsModule{..} =  HashMap.fromList $ fromDecls hsmodImports
   where
     fromDecls :: [LImportDecl name] -> [(Import name, SrcSpan)]
-    fromDecls lidecls = map toImportPairs $ zip lidecls [0..]
+    fromDecls lidecls =  zipWith (curry toImportPairs) lidecls [0 .. ]
 
     toImportPairs :: (LImportDecl name, Int) -> (Import name, SrcSpan)
     toImportPairs (L l impDecl, i) = (toMyImport impDecl i, l)

--- a/src/Smuggler/Import.hs
+++ b/src/Smuggler/Import.hs
@@ -1,97 +1,89 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Smuggler.Import where
 
-{-# LANGUAGE FlexibleInstances    #-}
+import Control.Monad (guard)
+import qualified Data.HashMap.Strict as HashMap ()
+import HsImpExp
+  ( IE (IEThingAbs, IEThingAll, IEThingWith, IEVar),
+    IEWrappedName (IEName),
+    ImportDecl (ideclHiding, ideclName),
+    LIE,
+    LIEWrappedName,
+  )
+import HsSyn (GhcRn)
+import Name (Name, nameSrcSpan)
+import PrelNames (pRELUDE_NAME)
+import RnNames (ImportDeclUsage)
+import SrcLoc
+  ( GenLocated (L),
+    SrcSpan (RealSrcSpan, UnhelpfulSpan),
+    srcSpanEndCol,
+    srcSpanStartCol,
+    srcSpanStartLine,
+    unLoc,
+  )
 
-module Smuggler.Import
-       ( Import (..)
-       , getLocationMap
-       ) where
+-- TODO: reuse more logic from GHC. Is it possible?
+unusedLocs :: ImportDeclUsage -> [(Int, Int)]
+unusedLocs (L (UnhelpfulSpan _) _, _, _) = []
+unusedLocs (L (RealSrcSpan loc) decl, used, unused)
+  | -- Do not remove `import M ()`
+    Just (False, L _ []) <- ideclHiding decl
+  = []
+  | -- Note [Do not warn about Prelude hiding]
+    -- TODO: add ability to support custom prelude
+    Just (True, L _ hides) <- ideclHiding decl
+  , not (null hides)
+  , pRELUDE_NAME == unLoc (ideclName decl)
+  = []
+  | {-
+        This is is not always correct, because instances may be imported
+        as in first case above
+    
+        -- Nothing used; drop entire decl
+        | null used = [ (lineNum, colNum)
+                      | lineNum <- [srcSpanStartLine loc .. srcSpanEndLine loc]
+                      , colNum <-  [srcSpanStartCol loc .. getEndColMax unused]
+                      ]
+    -}
 
-import BasicTypes (StringLiteral (..))
-import HsImpExp (IE (..), IEWildcard (..), IEWrappedName (..), ImportDecl (..), LIE, LIEWrappedName,
-                 LImportDecl)
-import HsSyn (HsModule (..))
-import Module (ModuleName, moduleName, moduleNameString)
-import Name (nameOccName)
-import OccName (occNameString)
-import RdrName (RdrName (..))
-import SrcLoc (GenLocated (L), Located, SrcSpan)
+    -- Everything imported is used; drop nothing
+    null unused
+  = []
+  | -- only part of non-hiding import is used
+    Just (False, L _ lies) <- ideclHiding decl
+  = unusedLies lies
+  | -- TODO: unused hidings
+    otherwise
+  = []
+ where
+  unusedLies :: [LIE GhcRn] -> [(Int, Int)]
+  unusedLies = concatMap lieToLoc
 
-import Smuggler.Loc (showL, showLoc)
+  lieToLoc :: LIE GhcRn -> [(Int, Int)]
+  lieToLoc (L _ lie) = case lie of
+    IEVar      _ name            -> lieNameToLoc name
+    IEThingAbs _ name            -> lieNameToLoc name
+    IEThingAll _ name            -> lieNameToLoc name
+    IEThingWith _ name _ names _ -> concatMap lieNameToLoc (name : names)
+    _                            -> []
 
-import qualified Data.HashMap.Strict as HashMap
-import qualified Text.Show as Show (show)
+  lieNameToLoc :: LIEWrappedName Name -> [(Int, Int)]
+  lieNameToLoc lieName = do
+    L _ (IEName (L (RealSrcSpan lieLoc) name)) <- [lieName]
+    guard $ name `elem` unused
+    pure (srcSpanStartLine lieLoc, srcSpanStartCol lieLoc)
 
-data Import name = Import
-    { impName      :: Located ModuleName -- ^ Module name.
-    , impPkgQual   :: Maybe StringLiteral  -- ^ Package qualifier.
-    , impQualified :: Bool          -- ^ True => qualified
-    , impImplicit  :: Bool          -- ^ True => implicit import (of Prelude)
-    , impAs        :: Maybe (Located ModuleName)  -- ^ as Module
-    , impHiding    :: Maybe (Bool, Located [LIE name]) -- ^ (True => hiding, names)
-    , impId        :: Int -- ^ For hashing
-    } deriving (Eq, Generic)
+  getEndColMax :: [Name] -> Int
+  getEndColMax u = listMax $ map (findColLoc . nameSrcSpan) u
 
-instance (Show name) => Show (Import name) where
-    show i = let L _ md = impName i in "Module: " ++ moduleNameString md ++
-        case impHiding i of
-            Just (b, L _ lies) -> " " ++ show b ++ " " ++ showLIEs lies
-            Nothing            -> ""
+  findColLoc :: SrcSpan -> Int
+  findColLoc (RealSrcSpan   l) = srcSpanEndCol l
+  findColLoc (UnhelpfulSpan _) = defaultCol
 
-showLIEs :: (Show name) => [LIE name] -> String
-showLIEs []   = ""
-showLIEs lies = "[ " ++ intercalate ", " (map showLIE lies) ++"]"
+defaultCol :: Int
+defaultCol = 120
 
-showLIE :: forall name . (Show name) => LIE name -> String
-showLIE (L _ ie) = showIE ie
-  where
-    showIE :: IE name -> String
-    showIE (IEVar lieWrappedName)       = showL " IEVar " showIEWrappedName lieWrappedName
-    showIE (IEThingAbs lieWrappedName)  = showL " IEThingAbs " showIEWrappedName lieWrappedName
-    showIE (IEThingAll lieWrappedName)  = showL " IEThingAll " showIEWrappedName lieWrappedName
-    showIE (IEThingWith lieWrappedName wildCard lieWNs _) = showL " IEThingWith " showIEWrappedName lieWrappedName
-        ++ showIEWildCard wildCard
-        ++ "[" ++ intercalate ", " (map showLIEWrappedName lieWNs) ++ "]"
-    showIE _ = "Not going to be"
-
-    showLIEWrappedName :: LIEWrappedName name -> String
-    showLIEWrappedName (L l ieWrappedName) = showLoc l ++ showIEWrappedName ieWrappedName
-
-    showIEWrappedName :: IEWrappedName name -> String
-    showIEWrappedName (IEName located)    = showL " IEName " show located
-    showIEWrappedName (IEPattern located) = showL " IEPattern " show located
-    showIEWrappedName (IEType located)    = showL " IEType " show located
-
-
-    showIEWildCard :: IEWildcard -> String
-    showIEWildCard NoIEWildcard   = ""
-    showIEWildCard (IEWildcard n) = "(..)" ++ show n
-
-instance Show RdrName where
-    show (Unqual occName)       = occNameString occName
-    show (Qual modName occName) = moduleNameString modName ++ " " ++ occNameString occName
-    show (Orig md occName)      = moduleNameString (moduleName md) ++ " " ++ occNameString occName
-    show (Exact nm)             = occNameString $ nameOccName nm
-
-instance Hashable (Import name) where
-    hashWithSalt salt = hashWithSalt salt . impId
-
-getLocationMap :: (Eq name) => HsModule name -> HashMap (Import name) SrcSpan
-getLocationMap HsModule{..} =  HashMap.fromList $ fromDecls hsmodImports
-  where
-    fromDecls :: [LImportDecl name] -> [(Import name, SrcSpan)]
-    fromDecls lidecls =  zipWith (curry toImportPairs) lidecls [0 .. ]
-
-    toImportPairs :: (LImportDecl name, Int) -> (Import name, SrcSpan)
-    toImportPairs (L l impDecl, i) = (toMyImport impDecl i, l)
-
-    toMyImport :: ImportDecl name -> Int -> Import name
-    toMyImport ImportDecl{..} i = Import
-        { impName      = ideclName
-        , impPkgQual   = ideclPkgQual
-        , impQualified = ideclQualified
-        , impImplicit  = ideclImplicit
-        , impAs        = ideclAs
-        , impHiding    = ideclHiding
-        , impId        = i
-        }
+listMax :: [Int] -> Int
+listMax []           = defaultCol
+listMax [x         ] = x
+listMax (x : y : xs) = listMax ((if x >= y then x else y) : xs)

--- a/src/Smuggler/Loc.hs
+++ b/src/Smuggler/Loc.hs
@@ -1,11 +1,9 @@
 module Smuggler.Loc
        ( showLoc
        , showL
-       , unL
        ) where
 
-import SrcLoc (GenLocated (L), Located, SrcSpan (RealSrcSpan), srcSpanStartCol, srcSpanStartLine,
-               unLoc)
+import SrcLoc (GenLocated (L), Located, SrcSpan (RealSrcSpan), srcSpanStartCol, srcSpanStartLine)
 
 -- | Returns location in the way of @line:col@.
 showLoc :: SrcSpan -> String
@@ -16,6 +14,3 @@ showLoc loc             = show loc
 showL :: String -> (a -> String) -> Located a -> String
 showL name showA (L l nm) = "(" ++ showLoc l ++ name ++ showA nm ++ ")"
 
--- | Shorter synonim for 'unLoc'.
-unL :: GenLocated l e -> e
-unL = unLoc

--- a/src/Smuggler/Loc.hs
+++ b/src/Smuggler/Loc.hs
@@ -1,14 +1,21 @@
 module Smuggler.Loc
-       ( showLoc
-       , showL
-       ) where
+  ( showLoc
+  , showL
+  )
+where
 
-import SrcLoc (GenLocated (L), Located, SrcSpan (RealSrcSpan), srcSpanStartCol, srcSpanStartLine)
+import           SrcLoc                         ( GenLocated(L)
+                                                , Located
+                                                , SrcSpan(RealSrcSpan)
+                                                , srcSpanStartCol
+                                                , srcSpanStartLine
+                                                )
 
 -- | Returns location in the way of @line:col@.
 showLoc :: SrcSpan -> String
-showLoc (RealSrcSpan r) = show (srcSpanStartLine r) ++ ":" ++ show (srcSpanStartCol r)
-showLoc loc             = show loc
+showLoc (RealSrcSpan r) =
+  show (srcSpanStartLine r) ++ ":" ++ show (srcSpanStartCol r)
+showLoc loc = show loc
 
 -- | Shows 'Located' in brackets.
 showL :: String -> (a -> String) -> Located a -> String

--- a/src/Smuggler/Name.hs
+++ b/src/Smuggler/Name.hs
@@ -1,11 +1,16 @@
 module Smuggler.Name
-       ( moduleBodyNames
-       ) where
+  ( moduleBodyNames
+  )
+where
 
-import Data.Generics.Schemes (listify)
-import GHC (GenLocated (..), ParsedSource)
-import HsSyn (HsModule (..))
-import OccName (OccName)
+import           Data.Generics.Schemes          ( listify )
+import           GHC                            ( GenLocated(..)
+                                                , ParsedSource
+                                                )
+import           HsSyn                          ( HsModule(..) )
+import           OccName                        ( OccName )
+import           Data.Containers.ListUtils      ( nubOrd )
 
 moduleBodyNames :: ParsedSource -> [OccName]
-moduleBodyNames (L _ ast) = ordNub $ listify (\(_ :: OccName) -> True) (hsmodDecls ast)
+moduleBodyNames (L _ ast) =
+  nubOrd $ listify (\(_ :: OccName) -> True) (hsmodDecls ast)

--- a/src/Smuggler/Options.hs
+++ b/src/Smuggler/Options.hs
@@ -1,0 +1,32 @@
+module Smuggler.Options (Options (..), parseCommandLineOptions)where
+
+import Data.Char (toLower)
+import           Plugins
+
+data ImportAction = NoImportProcessing | PreserveInstanceImports | MinimiseImports
+
+data ExportAction = NoExportProcessing | ExplicitExports | ReplaceExports
+
+data Options
+  = Options
+      { importAction :: ImportAction,
+        exportAction :: ExportAction,
+        newSuffix :: Maybe String
+      }
+
+defaultOptions :: Options
+defaultOptions = Options PreserveInstanceImports ExplicitExports Nothing
+
+parseCommandLineOption :: Options -> CommandLineOption -> Options
+parseCommandLineOption opts clo = case toLower <$> clo of
+  "noimportprocessing"      -> opts { importAction = NoImportProcessing }
+  "preserveinstanceimports" -> opts { importAction = PreserveInstanceImports }
+  "minimiseimports"         -> opts { importAction = MinimiseImports }
+  "noexportprocessing"      -> opts { exportAction = NoExportProcessing }
+  "explicitexports"         -> opts { exportAction = ExplicitExports }
+  "replaceexports"          -> opts { exportAction = ReplaceExports }
+  suffix                    -> opts { newSuffix = Just suffix }
+
+
+parseCommandLineOptions :: [CommandLineOption] -> Options
+parseCommandLineOptions = foldl' parseCommandLineOption defaultOptions

--- a/src/Smuggler/Options.hs
+++ b/src/Smuggler/Options.hs
@@ -1,6 +1,11 @@
-module Smuggler.Options (Options (..), parseCommandLineOptions)where
+module Smuggler.Options
+  ( Options(..)
+  , parseCommandLineOptions
+  )
+where
 
-import Data.Char (toLower)
+import           Data.List                      ( foldl' )
+import           Data.Char                      ( toLower )
 import           Plugins
 
 data ImportAction = NoImportProcessing | PreserveInstanceImports | MinimiseImports

--- a/src/Smuggler/Options.hs
+++ b/src/Smuggler/Options.hs
@@ -5,7 +5,7 @@ import           Plugins
 
 data ImportAction = NoImportProcessing | PreserveInstanceImports | MinimiseImports
 
-data ExportAction = NoExportProcessing | ExplicitExports | ReplaceExports
+data ExportAction = NoExportProcessing | AddExplicitExports | ReplaceExports
 
 data Options
   = Options
@@ -15,7 +15,7 @@ data Options
       }
 
 defaultOptions :: Options
-defaultOptions = Options PreserveInstanceImports ExplicitExports Nothing
+defaultOptions = Options PreserveInstanceImports AddExplicitExports Nothing
 
 parseCommandLineOption :: Options -> CommandLineOption -> Options
 parseCommandLineOption opts clo = case toLower <$> clo of
@@ -23,7 +23,7 @@ parseCommandLineOption opts clo = case toLower <$> clo of
   "preserveinstanceimports" -> opts { importAction = PreserveInstanceImports }
   "minimiseimports"         -> opts { importAction = MinimiseImports }
   "noexportprocessing"      -> opts { exportAction = NoExportProcessing }
-  "explicitexports"         -> opts { exportAction = ExplicitExports }
+  "addexplicitexports"      -> opts { exportAction = AddExplicitExports }
   "replaceexports"          -> opts { exportAction = ReplaceExports }
   suffix                    -> opts { newSuffix = Just suffix }
 

--- a/src/Smuggler/Options.hs
+++ b/src/Smuggler/Options.hs
@@ -1,12 +1,15 @@
 module Smuggler.Options
   ( Options(..)
   , parseCommandLineOptions
+  , ImportAction(..)
+  , ExportAction(..)
   )
 where
 
-import           Data.List                      ( foldl' )
-import           Data.Char                      ( toLower )
-import           Plugins
+import Data.List ( foldl' )
+import Data.Char ( toLower )
+import Plugins ( CommandLineOption )
+
 
 data ImportAction = NoImportProcessing | PreserveInstanceImports | MinimiseImports
 
@@ -16,7 +19,7 @@ data Options
   = Options
       { importAction :: ImportAction,
         exportAction :: ExportAction,
-        newSuffix :: Maybe String
+        newExtension :: Maybe String
       }
 
 defaultOptions :: Options
@@ -30,7 +33,7 @@ parseCommandLineOption opts clo = case toLower <$> clo of
   "noexportprocessing"      -> opts { exportAction = NoExportProcessing }
   "addexplicitexports"      -> opts { exportAction = AddExplicitExports }
   "replaceexports"          -> opts { exportAction = ReplaceExports }
-  suffix                    -> opts { newSuffix = Just suffix }
+  extension                 -> opts { newExtension = Just extension }
 
 
 parseCommandLineOptions :: [CommandLineOption] -> Options

--- a/src/Smuggler/Parser.hs
+++ b/src/Smuggler/Parser.hs
@@ -17,8 +17,8 @@ runParser
 runParser fileName fileContents = do
   res <- parseModuleFromString fileName fileContents
   pure $ case res of
-    Left  (_srcSpan, _str) -> Left ()
-    Right x                -> Right x
+    Left  _ -> Left () -- The error case type changed in 8.10
+    Right x -> Right x
 
 -- newtype ParseException = ParseException String
 --     deriving (Show)

--- a/src/Smuggler/Parser.hs
+++ b/src/Smuggler/Parser.hs
@@ -3,8 +3,6 @@ module Smuggler.Parser
   )
 where
 
-import           Data.ByteString                ( ByteString )
-import           Data.ByteString.Char8          ( unpack )
 import           Language.Haskell.GHC.ExactPrint
                                                 ( Anns )
 import           Language.Haskell.GHC.ExactPrint.Parsers
@@ -15,9 +13,9 @@ import           SrcLoc                         ( Located )
 
 
 runParser
-  :: FilePath -> ByteString -> IO (Either () (Anns, Located (HsModule GhcPs)))
+  :: FilePath -> String -> IO (Either () (Anns, Located (HsModule GhcPs)))
 runParser fileName fileContents = do
-  res <- parseModuleFromString fileName (unpack fileContents)
+  res <- parseModuleFromString fileName fileContents
   pure $ case res of
     Left  (_srcSpan, _str) -> Left ()
     Right x                -> Right x

--- a/src/Smuggler/Parser.hs
+++ b/src/Smuggler/Parser.hs
@@ -1,22 +1,26 @@
 module Smuggler.Parser
-       ( runParser
-       ) where
+  ( runParser
+  )
+where
 
-import Data.ByteString (ByteString)
-import Data.ByteString.Char8 (unpack)
-import Language.Haskell.GHC.ExactPrint (Anns)
-import Language.Haskell.GHC.ExactPrint.Parsers (parseModuleFromString)
+import           Data.ByteString                ( ByteString )
+import           Data.ByteString.Char8          ( unpack )
+import           Language.Haskell.GHC.ExactPrint
+                                                ( Anns )
+import           Language.Haskell.GHC.ExactPrint.Parsers
+                                                ( parseModuleFromString )
+import           HsExtension                    ( GhcPs )
+import           HsSyn                          ( HsModule(..) )
+import           SrcLoc                         ( Located )
 
-import HsExtension (GhcPs)
-import HsSyn (HsModule (..))
-import SrcLoc (Located)
 
-runParser :: FilePath -> ByteString -> IO (Either () (Anns, Located (HsModule GhcPs)))
+runParser
+  :: FilePath -> ByteString -> IO (Either () (Anns, Located (HsModule GhcPs)))
 runParser fileName fileContents = do
-    res <- parseModuleFromString fileName (unpack fileContents)
-    pure $ case res of
-        Left (_srcSpan, _str) -> Left ()
-        Right x               -> Right x
+  res <- parseModuleFromString fileName (unpack fileContents)
+  pure $ case res of
+    Left  (_srcSpan, _str) -> Left ()
+    Right x                -> Right x
 
 -- newtype ParseException = ParseException String
 --     deriving (Show)

--- a/src/Smuggler/Plugin.hs
+++ b/src/Smuggler/Plugin.hs
@@ -1,32 +1,57 @@
 module Smuggler.Plugin
-       ( plugin
-       ) where
+  ( plugin
+  )
+where
 
-import Control.Monad (guard)
-import Control.Monad.IO.Class (MonadIO (..))
-import Data.List (foldl')
+import           Control.Monad                  ( guard )
+import           Control.Monad.IO.Class         ( MonadIO(..) )
+import           Data.List                      ( foldl' )
 
-import Language.Haskell.GHC.ExactPrint (exactPrint)
+import           Language.Haskell.GHC.ExactPrint
+                                                ( exactPrint )
 
-import System.FilePath ((-<.>))
+import           System.FilePath                ( (-<.>) )
 
-import HscTypes (ModSummary (..))
-import HsExtension (GhcRn)
-import HsImpExp (IE (..), IEWrappedName (..), ImportDecl (..), LIE, LIEWrappedName)
-import IOEnv (readMutVar)
-import Name (Name, nameSrcSpan)
-import Plugins (CommandLineOption, Plugin (..), PluginRecompile (..), defaultPlugin)
-import PrelNames (pRELUDE_NAME)
-import RdrName (GlobalRdrElt)
-import RnNames (ImportDeclUsage, findImportUsage)
-import SrcLoc (GenLocated (L), SrcSpan (..), srcSpanEndCol, srcSpanStartCol, srcSpanStartLine,
-               unLoc)
-import TcRnTypes (TcGblEnv (..), TcM)
+import           HscTypes                       ( ModSummary(..) )
+import           HsExtension                    ( GhcRn )
+import           HsImpExp                       ( IE(..)
+                                                , IEWrappedName(..)
+                                                , ImportDecl(..)
+                                                , LIE
+                                                , LIEWrappedName
+                                                )
+import           IOEnv                          ( readMutVar )
+import           Name                           ( Name
+                                                , nameSrcSpan
+                                                )
+import           Plugins                        ( CommandLineOption
+                                                , Plugin(..)
+                                                , PluginRecompile(..)
+                                                , defaultPlugin
+                                                )
+import           PrelNames                      ( pRELUDE_NAME )
+import           RdrName                        ( GlobalRdrElt )
+import           RnNames                        ( ImportDeclUsage
+                                                , findImportUsage
+                                                )
+import           SrcLoc                         ( GenLocated(L)
+                                                , SrcSpan(..)
+                                                , srcSpanEndCol
+                                                , srcSpanStartCol
+                                                , srcSpanStartLine
+                                                , unLoc
+                                                )
+import           TcRnTypes                      ( TcGblEnv(..)
+                                                , TcM
+                                                )
 
-import Smuggler.Anns (removeAnnAtLoc, removeTrailingCommas)
-import Smuggler.Parser (runParser)
+import           Smuggler.Anns                  ( removeAnnAtLoc
+                                                , removeTrailingCommas
+                                                )
+import           Smuggler.Parser                ( runParser )
 
-import qualified Data.ByteString as BS (readFile)
+import qualified Data.ByteString               as BS
+                                                ( readFile )
 
 
 plugin :: Plugin

--- a/src/Smuggler/Plugin.hs
+++ b/src/Smuggler/Plugin.hs
@@ -75,7 +75,8 @@ smugglerPlugin clis modSummary tcEnv = do
 
         let (anns', ast') =
               minimiseImports dflags (importAction options) user_imports uses
-                $ addExplicitExports dflags (exportAction options) allExports (anns, ast)
+                (anns, ast)
+--                $ addExplicitExports dflags (exportAction options) allExports (anns, ast)
 
         -- 4. Remove positions of unused imports from annotations
         putStrLn $ exactPrint ast' anns'

--- a/src/Smuggler/Plugin.hs
+++ b/src/Smuggler/Plugin.hs
@@ -1,20 +1,17 @@
+{-# LANGUAGE LambdaCase #-}
 module Smuggler.Plugin
   ( plugin
   )
 where
 
-import ApiAnnotation ()
 import Avail (AvailInfo)
-import Control.Monad (guard)
+import Control.Monad (guard, unless)
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.List (foldl')
-import Data.Maybe ()
 import Debug.Trace (traceM)
 import DynFlags (DynFlags, HasDynFlags (getDynFlags))
 import GHC.IO.Encoding (setLocaleEncoding, utf8)
 import HscTypes (ModSummary (..))
-import HsExtension ()
-import HsImpExp ()
 import HsSyn (GhcPs, GhcRn, HsModule (hsmodExports),
               IE (IEThingAbs, IEThingAll, IEThingWith, IEVar), IEWrappedName (IEName),
               ImportDecl (ideclHiding, ideclImplicit, ideclName), LIE, LIEWrappedName)
@@ -36,14 +33,12 @@ import Smuggler.Parser (runParser)
 import SrcLoc (GenLocated (L), Located, SrcSpan (..), srcSpanEndCol, srcSpanStartCol,
                srcSpanStartLine, unLoc)
 import System.FilePath ((-<.>))
-import TcRnExports ()
 import TcRnTypes (TcGblEnv (..), TcM)
-import Text.Pretty.Simple ()
-
 
 plugin :: Plugin
-plugin = defaultPlugin { typeCheckResultAction = smugglerPlugin,
-                         pluginRecompile = smugglerRecompile }
+plugin = defaultPlugin { typeCheckResultAction = smugglerPlugin
+                       , pluginRecompile       = smugglerRecompile
+                       }
 
 defaultCol :: Int
 defaultCol = 120
@@ -55,146 +50,149 @@ smugglerRecompile _ = return NoForceRecompile
 
 smugglerPlugin :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
 smugglerPlugin clis modSummary tcEnv = do
-    dflags <- getDynFlags
-    let modulePath = ms_hspp_file modSummary
-    uses <- readMutVar (tcg_used_gres tcEnv)
-    tcEnv <$ liftIO (smuggling dflags uses modulePath)
-  where
+  -- TODO:: Used only for debugging (showSDoc dflags (ppr _ ))
+  dflags <- getDynFlags
+  let modulePath = ms_hspp_file modSummary
+  uses <- readMutVar (tcg_used_gres tcEnv)
+  tcEnv <$ liftIO (smuggling dflags uses modulePath)
+ where
 
-    addExports
-      :: DynFlags
-      -> [AvailInfo]
-      -> (Anns, Located (HsModule GhcPs))
-      -> (Anns, Located (HsModule GhcPs))
-    addExports dflags exports (anns, ast@(L astLoc hsMod)) = do
-      let
-        names = mkNamesFromAvailInfos exports
-        (exports', (anns', n), s) =
-          -- runTransform :: Anns -> Transform a -> (a, (Anns, Int), [String])
+  addExplicitExports
+    :: DynFlags
+    -> [AvailInfo]
+    -> (Anns, Located (HsModule GhcPs))
+    -> (Anns, Located (HsModule GhcPs))
+  addExplicitExports dflags exports (anns, L astLoc hsMod) = do
+    let names = mkNamesFromAvailInfos exports
+
+        (exportsList, (anns', _n), _s) =
           runTransform anns $ mapM mkIEVarFromNameT names
 
-        addExportDecls
-          :: [Located (IE GhcPs)] -> Transform (Located (HsModule GhcPs))
-        addExportDecls expl = do
-          let hsMod' = hsMod { hsmodExports = Just $ L astLoc expl }
-          addParensT (L astLoc expl)
-          mapM_ addExportDeclAnnT expl
-          mapM_ addCommaT (init expl)
-
-          traceM $ "astLoc: " ++ show astLoc
-
+        annotate :: Transform (Located (HsModule GhcPs))
+        annotate = do
+          let lExportsList = L astLoc exportsList
+              hsMod' = hsMod { hsmodExports = Just lExportsList }
+          addParensT lExportsList
+          mapM_ addExportDeclAnnT exportsList
+          unless (null exportsList) $ mapM_ addCommaT (init exportsList)
           return (L astLoc hsMod')
 
-        (ast', (anns'', n'), s') = runTransform anns' (addExportDecls exports')
+        (ast, (anns'', _n'), _s') = runTransform anns' annotate
 
+    (anns'', ast)
 
-      (anns'', ast')
+  smuggling :: DynFlags -> [GlobalRdrElt] -> FilePath -> IO ()
+  smuggling dflags uses modulePath = do
 
-    smuggling :: DynFlags -> [GlobalRdrElt] -> FilePath -> IO ()
-    smuggling dflags uses modulePath = do
-        -- 0. Read file content as a UTF-8 string (GHC accepts only ASCII or UTF-8)
-        -- TODO: Use ms_hspp_buf instead, if we have it?
-        setLocaleEncoding utf8
-        fileContents <- readFile modulePath
+    -- 0. Read file content as a UTF-8 string (GHC accepts only ASCII or UTF-8)
+    -- TODO: Use ms_hspp_buf instead, if we have it?
+    setLocaleEncoding utf8
+    fileContents <- readFile modulePath
 
-        -- 1. Parse given file
-        runParser modulePath fileContents >>= \case
-            Left () -> pure ()  -- do nothing if file is invalid Haskell
-            Right (anns, ast@(L _loc hsMod)) -> do
+    -- 1. Parse given file
+    runParser modulePath fileContents >>= \case
+      Left  ()                         -> pure () -- do nothing if file is invalid Haskell
+      Right (anns, ast@(L _loc hsMod)) -> do
 
-                let allExports = tcg_exports tcEnv
-                putStrLn  $ "AllExports:" ++ showSDoc dflags (ppr allExports)
+        -- EXPORTS
 
-                -- hsmodExports :: Maybe (Located [LIE pass])
-                let currentExplicitExports = hsmodExports hsMod
-                putStrLn  $ "currentExplicitExports:" ++ showSDoc dflags (ppr currentExplicitExports)
+        -- What the mdule exports, implicitly or exportsListicitly
+        let allExports             = tcg_exports tcEnv
+        -- hsmodExports :: Maybe (Located [LIE pass])
+        let currentExplicitExports = hsmodExports hsMod
 
-                let (anns', ast') = case currentExplicitExports of
-                                      Just _  ->  (anns, ast) -- there is an existing export list
-                                      Nothing -> addExports dflags allExports (anns, ast)
---
---                              putStrLn  $ "ast':" ++ showSDoc dflags (ppr ast')
---                              putStrLn  $ "anns':" ++  showSDoc dflags (ppr anns')
-                putStrLn $ "exactPrint:\n" ++ exactPrint ast'  anns'
-                              --putStrLn $ exactPrint ast' (addAnnotationsForPretty [] ast' anns')
+        -- 2.  Annotate with exportsListicit export declaration, if there ism't an existing one
+        let (anns', ast') = case currentExplicitExports of
+              Just _ -> (anns, ast) -- there is an existing export export list
+              Nothing ->
+                addExplicitExports dflags allExports (anns, ast)
 
-                -- 2. find positions of unused imports
-                let user_imports = filter (not . ideclImplicit . unLoc) (tcg_rn_imports tcEnv)
-                let usage = findImportUsage user_imports uses
-                let unusedPositions = concatMap unusedLocs usage
+        -- IMPORTS
 
-                -- 3. Remove positions of unused imports from annotations
-                case unusedPositions of
-                    [] -> pure ()  -- do nothing if no unused imports
-                    unused -> do
-                        let purifiedAnnotations = removeTrailingCommas
-                                $ foldl' (\ann (x, y) -> removeAnnAtLoc x y ann) anns unused
-                        let newContent = exactPrint ast purifiedAnnotations
-                        case clis of
-                            []      -> writeFile modulePath newContent
-                            (ext:_) -> writeFile (modulePath -<.> ext) newContent
+        -- 3. find positions of unused imports
+        let user_imports =
+              filter (not . ideclImplicit . unLoc) (tcg_rn_imports tcEnv)
+        let usage           = findImportUsage user_imports uses
+        let unusedPositions = concatMap unusedLocs usage
+
+        -- 4. Remove positions of unused imports from annotations
+        case unusedPositions of
+          []     -> pure () -- do nothing if no unused imports
+          unused -> do
+            let purifiedAnnotations = removeTrailingCommas $ foldl'
+                  (\ann (x, y) -> removeAnnAtLoc x y ann)
+                  anns'
+                  unused
+            putStrLn $ exactPrint ast' purifiedAnnotations
+            let newContent = exactPrint ast' purifiedAnnotations
+            case clis of
+              []        -> writeFile modulePath newContent
+              (ext : _) -> writeFile (modulePath -<.> ext) newContent
 
 -- TODO: reuse more logic from GHC. Is it possible?
 unusedLocs :: ImportDeclUsage -> [(Int, Int)]
 unusedLocs (L (UnhelpfulSpan _) _, _, _) = []
 unusedLocs (L (RealSrcSpan loc) decl, used, unused)
-    -- Do not remove `import M ()`
-    | Just (False, L _ []) <- ideclHiding decl
-    = []
+  |
+  -- Do not remove `import M ()`
+    Just (False, L _ []) <- ideclHiding decl
+  = []
+  |
+  -- Note [Do not warn about Prelude hiding]
+  -- TODO: add ability to support custom prelude
+    Just (True, L _ hides) <- ideclHiding decl
+  , not (null hides)
+  , pRELUDE_NAME == unLoc (ideclName decl)
+  = []
+  |
+  {-
+      This is is not always correct, because instances may be imported
+      as in first case above
 
-    -- Note [Do not warn about Prelude hiding]
-    -- TODO: add ability to support custom prelude
-    | Just (True, L _ hides) <- ideclHiding decl
-    , not (null hides)
-    , pRELUDE_NAME == unLoc (ideclName decl)
-    = []
+      -- Nothing used; drop entire decl
+      | null used = [ (lineNum, colNum)
+                    | lineNum <- [srcSpanStartLine loc .. srcSpanEndLine loc]
+                    , colNum <-  [srcSpanStartCol loc .. getEndColMax unused]
+                    ]
+  -}
 
-{-
-    This is is not always correct, because instances may be imported
-    as in first case above
+  -- Everything imported is used; drop nothing
+    null unused
+  = []
+  |
+  -- only part of non-hiding import is used
+    Just (False, L _ lies) <- ideclHiding decl
+  = unusedLies lies
+  |
+  -- TODO: unused hidings
+    otherwise
+  = []
+ where
+  unusedLies :: [LIE GhcRn] -> [(Int, Int)]
+  unusedLies = concatMap lieToLoc
 
-    -- Nothing used; drop entire decl
-    | null used = [ (lineNum, colNum)
-                  | lineNum <- [srcSpanStartLine loc .. srcSpanEndLine loc]
-                  , colNum <-  [srcSpanStartCol loc .. getEndColMax unused]
-                  ]
--}
+  lieToLoc :: LIE GhcRn -> [(Int, Int)]
+  lieToLoc (L _ lie) = case lie of
+    IEVar      _ name            -> lieNameToLoc name
+    IEThingAbs _ name            -> lieNameToLoc name
+    IEThingAll _ name            -> lieNameToLoc name
+    IEThingWith _ name _ names _ -> concatMap lieNameToLoc (name : names)
+    _                            -> []
 
-    -- Everything imported is used; drop nothing
-    | null unused = []
+  lieNameToLoc :: LIEWrappedName Name -> [(Int, Int)]
+  lieNameToLoc lieName = do
+    L _ (IEName (L (RealSrcSpan lieLoc) name)) <- [lieName]
+    guard $ name `elem` unused
+    pure (srcSpanStartLine lieLoc, srcSpanStartCol lieLoc)
 
-    -- only part of non-hiding import is used
-    | Just (False, L _ lies) <- ideclHiding decl
-    = unusedLies lies
+  getEndColMax :: [Name] -> Int
+  getEndColMax u = listMax $ map (findColLoc . nameSrcSpan) u
 
-    -- TODO: unused hidings
-    | otherwise = []
-  where
-    unusedLies :: [LIE GhcRn] -> [(Int, Int)]
-    unusedLies = concatMap lieToLoc
-
-    lieToLoc :: LIE GhcRn -> [(Int, Int)]
-    lieToLoc (L _ lie) = case lie of
-        IEVar _ name                 -> lieNameToLoc name
-        IEThingAbs _ name            -> lieNameToLoc name
-        IEThingAll _ name            -> lieNameToLoc name
-        IEThingWith _ name _ names _ -> concatMap lieNameToLoc (name : names)
-        _                            -> []
-
-    lieNameToLoc :: LIEWrappedName Name -> [(Int, Int)]
-    lieNameToLoc lieName = do
-        L _ (IEName (L (RealSrcSpan lieLoc) name)) <- [lieName]
-        guard $ name `elem` unused
-        pure (srcSpanStartLine lieLoc, srcSpanStartCol lieLoc)
-
-    getEndColMax :: [Name] -> Int
-    getEndColMax u = listMax $ map (findColLoc . nameSrcSpan) u
-
-    findColLoc :: SrcSpan -> Int
-    findColLoc (RealSrcSpan l)   = srcSpanEndCol l
-    findColLoc (UnhelpfulSpan _) = defaultCol
+  findColLoc :: SrcSpan -> Int
+  findColLoc (RealSrcSpan   l) = srcSpanEndCol l
+  findColLoc (UnhelpfulSpan _) = defaultCol
 
 listMax :: [Int] -> Int
-listMax []       = defaultCol
-listMax [x]      = x
-listMax (x:y:xs) = listMax ((if x >= y then x else y):xs)
+listMax []           = defaultCol
+listMax [x         ] = x
+listMax (x : y : xs) = listMax ((if x >= y then x else y) : xs)

--- a/src/Smuggler/Plugin.hs
+++ b/src/Smuggler/Plugin.hs
@@ -65,13 +65,15 @@ smugglerPlugin clis modSummary tcEnv = do
     (ast', (anns', _n), _s) = runTransform anns $ do
 
       let names = mkNamesFromAvailInfos exports
+
       exportsList <- mapM mkIEVarFromNameT names
+      mapM_ addExportDeclAnnT exportsList
+      unless (null exportsList) $ mapM_ addCommaT (init exportsList)
 
       let lExportsList = L astLoc exportsList
           hsMod'       = hsMod { hsmodExports = Just lExportsList }
       addParensT lExportsList
-      mapM_ addExportDeclAnnT exportsList
-      unless (null exportsList) $ mapM_ addCommaT (init exportsList)
+
       return (L astLoc hsMod')
 
   smuggling :: DynFlags -> [GlobalRdrElt] -> FilePath -> IO ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,2 @@
-resolver: lts-14.4
+resolver: lts-15.7
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -45,9 +45,9 @@ main = do
     outputFailure :: String -> String -> IO ()
     outputFailure given expected = do
       boldMessage "Expected:"
-      putStrLn (importStatementsOnly expected)
+      putStrLn expected
       boldMessage "But got:"
-      putStrLn (importStatementsOnly given)
+      putStrLn given
 
 successCode, failureCode, resetCode :: [SGR]
 successCode = [SetColor Foreground Dull Green]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -20,6 +20,7 @@ main = do
     putStrLn "Cleaning tests"
     for_ testFiles removeFile
 
+    -- TODO: redundant?
     -- clean up .smuggler/ cache directory
     cacheDirExists <- doesDirectoryExist ".smuggler"
     when cacheDirExists $ do

--- a/test/Test/ExportExplicit.golden
+++ b/test/Test/ExportExplicit.golden
@@ -1,0 +1,10 @@
+module Test.ExportExplicit (isExported, anotherExport, andAnother) where
+
+isExported = (+1)
+
+anotherExport = True
+
+andAnother = 27
+
+main :: IO ()
+main = pure ()

--- a/test/Test/ExportExplicit.hs
+++ b/test/Test/ExportExplicit.hs
@@ -1,0 +1,10 @@
+module Test.ExportExplicit (isExported, anotherExport, andAnother) where
+
+isExported = (+1)
+
+anotherExport = True
+
+andAnother = 27
+
+main :: IO ()
+main = pure ()

--- a/test/Test/ExportImplicit.golden
+++ b/test/Test/ExportImplicit.golden
@@ -1,0 +1,8 @@
+module Test.ExportImplicit where
+
+isExported = (+1)
+
+alsoExported = True
+
+main :: IO ()
+main = print $ isExported 1

--- a/test/Test/ExportImplicit.hs
+++ b/test/Test/ExportImplicit.hs
@@ -1,8 +1,10 @@
 module Test.ExportImplicit where
 
+import Data.Char
+
 isExported = (+1)
 
-alsoExported = True
+alsoExported = map toLower "AbC"
 
 main :: IO ()
 main = print $ isExported 1

--- a/test/Test/ExportImplicit.hs
+++ b/test/Test/ExportImplicit.hs
@@ -1,0 +1,8 @@
+module Test.ExportImplicit where
+
+isExported = (+1)
+
+alsoExported = True
+
+main :: IO ()
+main = print $ isExported 1

--- a/test/Test/ImplicitImportUnused.hs
+++ b/test/Test/ImplicitImportUnused.hs
@@ -1,5 +1,9 @@
 module Test.ImplicitImportUnused where
 
 import Data.List
+import Data.Bool (not, (&&))
+import Data.Maybe (fromMaybe, isJust, isNothing)
 
-foo = id
+foo = isJust
+
+bar = 27


### PR DESCRIPTION
This PR updates the dependencies for GHC 8.8.3 and adds a debug flag to the cabal file to allow for easier compilation of modules that were commented out in the original.

I've also commented out one `unusedLoc` case, to align with GHC behaviour.  Previously it completely removed a module import if it was `unused`.  But it might be being used to import typeclass instances, so now it just gets pruned back to a `import Mod ()`.  This is less pretty than just excising the module import, but it means that the plugin doesn't break anything.  Perhaps it would be better to control this behavior with a plugin flag.

The tests don't all pass (as was the case before this PR).  Some of the tests fail because we retain import stubs.  Others fail because functions such as `not` are included in the standard Prelude and so they can be removed from explicit `Data.Bool` import lists.    This could rectified by updating the golden values.

There is a way of controlling whether a module gets recompiled after this plug-in has run.  I've included a stub to that facility, but not changed from the default behaviour.  (The test check for a `.smuggler`
cache, which I don't think is used any longer.)

Apologies for the whitespace changes.  They are mainly to the imports, so that the lengthy ones are more readable (to me).  I've also reformatted the cabal file with cabal-fmt to give a consistent format baseline.